### PR TITLE
fix: correct relation/column names in DetachFamilyToMasterSubDepartment

### DIFF
--- a/app/Actions/Masters/MasterProductCategory/DetachFamilyToMasterSubDepartment.php
+++ b/app/Actions/Masters/MasterProductCategory/DetachFamilyToMasterSubDepartment.php
@@ -21,13 +21,13 @@ class DetachFamilyToMasterSubDepartment extends GrpAction
 
     public function handle(MasterProductCategory $family): MasterProductCategory
     {
-        $currentSubDepartment = $family->subDepartment;
+        $currentSubDepartment = $family->masterSubDepartment;
 
         $family->update(
             [
-                'sub_department_id' => null,
-                'department_id'     => $currentSubDepartment->department_id,
-                'parent_id'         => $currentSubDepartment->department_id,
+                'master_sub_department_id' => null,
+                'master_department_id'     => $currentSubDepartment->master_department_id,
+                'master_parent_id'         => $currentSubDepartment->master_department_id,
             ]
         );
 

--- a/tests/Feature/AikuSections/MastersTest.php
+++ b/tests/Feature/AikuSections/MastersTest.php
@@ -20,6 +20,8 @@ use App\Actions\Masters\MasterCollection\HydrateMasterCollection as HydrateMaste
 use App\Actions\Masters\MasterCollection\StoreMasterCollection;
 use App\Actions\Masters\MasterCollection\UI\GetMasterCollectionShowcase;
 use App\Actions\Masters\MasterCollection\UpdateMasterCollection;
+use App\Actions\Masters\MasterProductCategory\AttachMasterFamiliesToMasterSubDepartment;
+use App\Actions\Masters\MasterProductCategory\DetachFamilyToMasterSubDepartment;
 use App\Actions\Masters\MasterProductCategory\StoreMasterDepartment;
 use App\Actions\Masters\MasterProductCategory\StoreMasterFamily;
 use App\Actions\Masters\MasterProductCategory\StoreMasterProductCategory;
@@ -670,6 +672,40 @@ test('store master family', function (MasterProductCategory $masterDepartment) {
         ->and($masterFamily->group_id)->toBe($this->group->id)
         ->and($masterFamily->type)->toBe(MasterProductCategoryTypeEnum::FAMILY)
         ->and($masterFamily->stats)->toBeInstanceOf(MasterProductCategoryStats::class);
+})->depends('store master department');
+
+test('detach family from master sub department', function (MasterProductCategory $masterDepartment) {
+    $masterSubDepartment = StoreMasterSubDepartment::make()->action(
+        $masterDepartment,
+        [
+            'code' => 'SMF_SUBDEPT1',
+            'name' => 'smf sub department 1',
+        ]
+    );
+
+    $masterFamily = StoreMasterFamily::make()->action(
+        $masterDepartment,
+        [
+            'code' => 'SMF_FAM_DETACH',
+            'name' => 'smf family to detach',
+        ]
+    );
+
+    AttachMasterFamiliesToMasterSubDepartment::make()->action(
+        $masterSubDepartment,
+        ['master_families' => [$masterFamily->id]]
+    );
+
+    $masterFamily->refresh();
+    expect($masterFamily->master_sub_department_id)->toBe($masterSubDepartment->id);
+
+    DetachFamilyToMasterSubDepartment::make()->handle($masterFamily);
+
+    $masterFamily->refresh();
+
+    expect($masterFamily->master_sub_department_id)->toBeNull()
+        ->and($masterFamily->master_department_id)->toBe($masterDepartment->id)
+        ->and($masterFamily->master_parent_id)->toBe($masterDepartment->id);
 })->depends('store master department');
 
 


### PR DESCRIPTION
## Summary
- Fixes `DetachFamilyToMasterSubDepartment::handle()`, which called a non-existent `subDepartment` relation and updated non-existent `sub_department_id`/`department_id`/`parent_id` columns. Now uses `masterSubDepartment` and the `master_*` prefixed columns, matching `AttachMasterFamiliesToMasterSubDepartment`.
- Adds a feature test covering attach + detach of a master family from a master sub department.

## Test plan
- [x] `php -l` on changed files
- [ ] `php artisan test --compact --filter="detach family from master sub department"` (run in a dev environment with vendor installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)