### PR TITLE
feat: 📋 paste ingredients list on trade unit edit

### DIFF
--- a/app/Actions/Goods/Ingredient/Json/ParseIngredientsList.php
+++ b/app/Actions/Goods/Ingredient/Json/ParseIngredientsList.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright 2026
+*/
+
+namespace App\Actions\Goods\Ingredient\Json;
+
+use App\Actions\Goods\Ingredient\StoreIngredient;
+use App\Actions\OrgAction;
+use App\Actions\Traits\Authorisations\WithGoodsEditAuthorisation;
+use App\Models\Goods\Ingredient;
+use App\Models\SysAdmin\Group;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\ActionRequest;
+
+class ParseIngredientsList extends OrgAction
+{
+    use WithGoodsEditAuthorisation;
+
+    /**
+     * @return array<int, array{name: string, slug: string|null, is_new: bool}>
+     */
+    public function handle(Group $group, string $text, bool $commit): array
+    {
+        $names = $this->extractNames($text);
+
+        $existing = Ingredient::where('group_id', $group->id)
+            ->whereIn(DB::raw('lower(name)'), array_map('mb_strtolower', $names))
+            ->get()
+            ->keyBy(fn (Ingredient $ingredient) => mb_strtolower($ingredient->name));
+
+        return collect($names)->map(function (string $name) use ($group, $existing, $commit) {
+            $ingredient = $existing->get(mb_strtolower($name));
+
+            if ($ingredient) {
+                return ['name' => $ingredient->name, 'slug' => $ingredient->slug, 'is_new' => false];
+            }
+
+            if (!$commit) {
+                return ['name' => $name, 'slug' => null, 'is_new' => true];
+            }
+
+            $ingredient = StoreIngredient::make()->action($group, ['name' => $name]);
+
+            return ['name' => $ingredient->name, 'slug' => $ingredient->slug, 'is_new' => true];
+        })->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function extractNames(string $text): array
+    {
+        return collect(preg_split('/[,;\r\n]+/', $text))
+            ->map(fn ($name) => trim(preg_replace('/[*†\x{00B0}]+$/u', '', trim($name))))
+            ->filter()
+            ->unique(fn (string $name) => mb_strtolower($name))
+            ->values()
+            ->all();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'text'   => ['required', 'string', 'max:20000'],
+            'commit' => ['sometimes', 'boolean'],
+        ];
+    }
+
+    public function asController(ActionRequest $request): array
+    {
+        $this->initialisationFromGroup(group(), $request);
+
+        return $this->handle(group(), $this->validatedData['text'], (bool)($this->validatedData['commit'] ?? false));
+    }
+}

--- a/app/Actions/Goods/TradeUnit/UI/EditTradeUnit.php
+++ b/app/Actions/Goods/TradeUnit/UI/EditTradeUnit.php
@@ -284,13 +284,17 @@ class EditTradeUnit extends OrgAction
                             'icon'   => 'fa-light fa-book-open',
                             'fields' => [
                                 'ingredients' => [
-                                    'type'  => 'select_infinite',
+                                    'type'  => 'ingredients',
                                     'label' => __('Ingredients'),
                                     'value' => $tradeUnit->ingredients->pluck('slug')->all(),
                                     'mode' => 'tags',
                                     'options' => IngredientsResource::collection($tradeUnit->ingredients)->resolve(),
                                     'fetchRoute' => [
                                         'name'       => 'grp.goods.ingredients.index',
+                                        'parameters' => []
+                                    ],
+                                    'parseRoute' => [
+                                        'name'       => 'grp.json.ingredients.parse',
                                         'parameters' => []
                                     ],
                                     'valueProp'  => 'slug',

--- a/resources/js/Components/Forms/Fields/IngredientsField.vue
+++ b/resources/js/Components/Forms/Fields/IngredientsField.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { ref } from "vue"
+import axios from "axios"
+import { trans } from "laravel-vue-i18n"
+import { notify } from "@kyvg/vue3-notification"
+import SelectInfiniteScroll from "@/Components/Forms/Fields/SelectInfiniteScroll.vue"
+import Button from "@/Components/Elements/Buttons/Button.vue"
+import Modal from "@/Components/Utils/Modal.vue"
+import { routeType } from "@/types/route"
+
+type ParsedIngredient = { name: string; slug: string | null; is_new: boolean }
+
+const props = defineProps<{
+    form: any
+    fieldName: string
+    options: { slug: string; name: string }[]
+    fieldData: {
+        fetchRoute: routeType
+        parseRoute: routeType
+        [key: string]: any
+    }
+}>()
+
+const localOptions = ref([...(props.options ?? [])])
+const isModalOpen = ref(false)
+const pastedText = ref("")
+const preview = ref<ParsedIngredient[] | null>(null)
+const isLoading = ref(false)
+
+const parse = async (commit: boolean, replace = false) => {
+    isLoading.value = true
+    try {
+        const response = await axios.post(
+            route(props.fieldData.parseRoute.name, props.fieldData.parseRoute.parameters),
+            { text: pastedText.value, commit }
+        )
+
+        if (!commit) {
+            preview.value = response.data
+            return
+        }
+
+        const parsed: ParsedIngredient[] = response.data
+        const selected = new Set(replace ? [] : props.form[props.fieldName] ?? [])
+
+        for (const ingredient of parsed) {
+            if (!ingredient.slug) {
+                continue
+            }
+            if (!localOptions.value.some((option) => option.slug === ingredient.slug)) {
+                localOptions.value.push({ slug: ingredient.slug, name: ingredient.name })
+            }
+            selected.add(ingredient.slug)
+        }
+
+        props.form[props.fieldName] = [...selected]
+        closeModal()
+    } catch (error: any) {
+        notify({
+            title: trans("Something went wrong"),
+            text: error.response?.data?.message ?? trans("Failed to parse the ingredients"),
+            type: "error",
+        })
+    } finally {
+        isLoading.value = false
+    }
+}
+
+const closeModal = () => {
+    isModalOpen.value = false
+    pastedText.value = ""
+    preview.value = null
+}
+</script>
+
+<template>
+    <div>
+        <SelectInfiniteScroll
+            :form="form"
+            :fieldName="fieldName"
+            :options="localOptions"
+            :fieldData="fieldData"
+        />
+
+        <div class="mt-2">
+            <Button
+                type="tertiary"
+                size="xs"
+                icon="fal fa-paste"
+                :label="trans('Paste list')"
+                @click="isModalOpen = true"
+            />
+        </div>
+
+        <Modal :isOpen="isModalOpen" @onClose="closeModal" width="w-full max-w-2xl">
+            <div class="text-left">
+                <div class="text-lg mb-2">{{ trans("Paste ingredients") }}</div>
+                <div class="text-sm text-gray-500 mb-3">
+                    {{ trans("Separated by commas or new lines. Trailing asterisks are ignored.") }}
+                </div>
+
+                <textarea
+                    v-model="pastedText"
+                    rows="6"
+                    class="w-full rounded border-gray-300 text-sm"
+                    :placeholder="trans('Aqua, Glycerin, Parfum, Linalool*')"
+                    @input="preview = null"
+                />
+
+                <div v-if="preview" class="mt-3">
+                    <div class="text-sm text-gray-500 mb-1">
+                        {{ trans("Preview") }}: {{ preview.length }}
+                        <span v-if="preview.some((ingredient) => ingredient.is_new)">
+                            ({{ preview.filter((ingredient) => ingredient.is_new).length }} {{ trans("new") }})
+                        </span>
+                    </div>
+                    <div class="flex flex-wrap gap-1 max-h-60 overflow-y-auto">
+                        <span
+                            v-for="ingredient in preview"
+                            :key="ingredient.name"
+                            class="px-2 py-0.5 rounded text-sm"
+                            :class="ingredient.is_new ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-700'"
+                        >
+                            {{ ingredient.name }}
+                        </span>
+                    </div>
+                </div>
+
+                <div class="mt-4 flex items-center justify-end gap-2 whitespace-nowrap">
+                    <div v-if="preview" class="mr-auto text-xs text-gray-500 whitespace-normal">
+                        {{
+                            trans("Replace all removes the :count ingredient(s) currently selected. Add to current keeps them.", {
+                                count: (form[fieldName] ?? []).length,
+                            })
+                        }}
+                    </div>
+
+                    <Button
+                        v-if="!preview"
+                        :label="trans('Next')"
+                        :disabled="!pastedText.trim()"
+                        :loading="isLoading"
+                        @click="parse(false)"
+                    />
+                    <template v-else>
+                        <Button
+                            type="tertiary"
+                            :label="trans('Replace all')"
+                            :loading="isLoading"
+                            @click="parse(true, true)"
+                        />
+                        <Button
+                            :label="trans('Add to current')"
+                            :loading="isLoading"
+                            @click="parse(true)"
+                        />
+                    </template>
+                </div>
+            </div>
+        </Modal>
+    </div>
+</template>

--- a/resources/js/Composables/Listing/FieldFormList.ts
+++ b/resources/js/Composables/Listing/FieldFormList.ts
@@ -97,6 +97,7 @@ import BannedCountries from '@/Components/Forms/Fields/BannedCountries.vue'
 import FieldGroup from '@/Components/Forms/Fields/FieldGroup.vue'
 import MultiplePriceCurrency from '@/Components/Forms/Fields/MultiplePriceCurrency.vue'
 import MasterShopPriceExchanges from '@/Components/Forms/Fields/MasterShopPriceExchanges.vue'
+import IngredientsField from '@/Components/Forms/Fields/IngredientsField.vue'
 
 export const componentsList: { [key: string]: Component } = {
     'image_crop_square': ImageCropSquare,
@@ -153,6 +154,7 @@ export const componentsList: { [key: string]: Component } = {
     'button': ButtonForm,
     'input_translation': InputTranslation,
     'select_infinite': SelectInfiniteScroll,
+    'ingredients': IngredientsField,
     'textEditor_translation': TextEditorTranslation,
     'pricing_zone': Pricing_zone,
     'territory_zone': TerritoryZone,

--- a/routes/grp/web/json.php
+++ b/routes/grp/web/json.php
@@ -89,6 +89,7 @@ use App\Actions\Fulfilment\PalletDelivery\Json\GetFulfilmentServices;
 use App\Actions\Fulfilment\PalletDelivery\UI\IndexRecentPalletDeliveryUploads;
 use App\Actions\Fulfilment\PalletReturn\Json\GetPalletsInReturnPalletWholePallets;
 use App\Actions\Fulfilment\StoredItem\Json\GetPalletAuditStoredItems;
+use App\Actions\Goods\Ingredient\Json\ParseIngredientsList;
 use App\Actions\Goods\TradeUnit\UI\GetTradeUnitsForTradeUnitFamily;
 use App\Actions\Helpers\Address\GetGeocode;
 use App\Actions\Helpers\Brand\Json\GetBrands;
@@ -342,3 +343,5 @@ Route::get('{website}/webpages-for-workshop-select', GetWebpagesForWorkshopSelec
 
 // Families list under department page
 Route::get('{productCategory}/family-under-department', GetFamiliesUnderDepartmentPage::class)->name('website.category.family_under_department');
+
+Route::post('ingredients/parse', ParseIngredientsList::class)->name('ingredients.parse');

--- a/tests/Feature/GoodsTest.php
+++ b/tests/Feature/GoodsTest.php
@@ -8,6 +8,7 @@
 
 /** @noinspection PhpUnhandledExceptionInspection */
 
+use App\Actions\Goods\Ingredient\Json\ParseIngredientsList;
 use App\Actions\Goods\Ingredient\StoreIngredient;
 use App\Actions\Goods\Ingredient\UpdateIngredient;
 use App\Actions\Goods\Stock\HydrateStocks;
@@ -146,6 +147,24 @@ test('update ingredient', function (Ingredient $ingredient) {
 
     return $ingredient;
 })->depends('store ingredient');
+
+test('parse pasted ingredients list', function () {
+    StoreIngredient::make()->action($this->group, ['name' => 'Aqua']);
+
+    $parsed = ParseIngredientsList::make()->handle($this->group, "aqua, Linalool*\nGlycerin, , Glycerin", false);
+
+    expect($parsed)->toHaveCount(3)
+        ->and($parsed[0])->toBe(['name' => 'Aqua', 'slug' => 'aqua', 'is_new' => false])
+        ->and($parsed[1]['name'])->toBe('Linalool')
+        ->and($parsed[1]['is_new'])->toBeTrue()
+        ->and($parsed[1]['slug'])->toBeNull()
+        ->and(Ingredient::where('name', 'Linalool')->exists())->toBeFalse();
+
+    $committed = ParseIngredientsList::make()->handle($this->group, 'Linalool*', true);
+
+    expect($committed[0]['slug'])->not->toBeNull()
+        ->and(Ingredient::where('name', 'Linalool')->exists())->toBeTrue();
+});
 
 test('index ingredients', function () {
     $count = Ingredient::count();


### PR DESCRIPTION
Fixes the pain in HELP-2841: adding ingredients one by one on a trade unit takes ages, and some ingredients on the label don't exist in Aiku yet.

## What

A **Paste list** button under the Ingredients field opens a modal:

1. Paste the label's ingredient list (commas, semicolons or new lines).
2. **Next** → preview of the parsed ingredients, with the ones that don't exist yet highlighted amber.
3. **Replace all** (swaps the whole list) or **Add to current** (merges) — missing ingredients are created at that point, not before.

Parsing trims, dedupes case-insensitively, and strips trailing asterisks, so `Geranyl Acetate*` matches the existing `Geranyl Acetate`.

## How

- `ParseIngredientsList` (`POST json/ingredients/parse`) — resolves names against the group's ingredients by `lower(name)`; with `commit: false` it only reports what is new, with `commit: true` it creates them via `StoreIngredient`.
- `IngredientsField.vue` — wraps the existing `SelectInfiniteScroll`, adds the button + modal. New field type `ingredients`; `EditTradeUnit` switched over.

Covered by `parse pasted ingredients list` in `GoodsTest` (dedupe, asterisk, dry-run creates nothing, commit creates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)