### PR TITLE
perf: 🖼️ dedupe imgproxy URLs in iris product card payloads

### DIFF
--- a/app/Http/Resources/Traits/HasCardWebImages.php
+++ b/app/Http/Resources/Traits/HasCardWebImages.php
@@ -33,11 +33,52 @@ trait HasCardWebImages
             }
 
             $cardWebImages[$slot] = [
-                'gallery' => Arr::only($gallery, ['avif', 'avif_2x', 'webp', 'webp_2x', 'original', 'original_2x']),
+                'gallery' => $this->compactGallery(Arr::only($gallery, ['avif', 'avif_2x', 'webp', 'webp_2x', 'original', 'original_2x'])),
             ];
         }
 
         return $cardWebImages;
+    }
+
+    /**
+     * All imgproxy variants of one image share the same host and base64 source tail;
+     * only the signature/processing prefix and extension differ. Ship the shared parts
+     * once ({_cig: {u, b}}) and per-variant "prefix|ext" strings; the frontend Image
+     * component reassembles the urls. Any url that does not match the expected shape
+     * makes the whole gallery fall back to full urls.
+     *
+     * @param array<string, string> $gallery
+     */
+    protected function compactGallery(array $gallery): array
+    {
+        $host = null;
+        $base = null;
+        $variants = [];
+
+        foreach ($gallery as $format => $url) {
+            if (!is_string($url) || !preg_match('#^(https?://[^/]+)/([^/]+/.+)/([A-Za-z0-9_=-]+)(\.\w+)?$#', $url, $m)) {
+                return $gallery;
+            }
+
+            [, $urlHost, $prefix, $urlBase, $ext] = array_pad($m, 5, '');
+
+            if (($host !== null && $urlHost !== $host) || ($base !== null && $urlBase !== $base)) {
+                return $gallery;
+            }
+
+            $host = $urlHost;
+            $base = $urlBase;
+            $variants[$format] = $prefix.'|'.$ext;
+        }
+
+        if ($variants === []) {
+            return $gallery;
+        }
+
+        return [
+            '_cig' => ['u' => $host, 'b' => $base],
+            'v'    => $variants,
+        ];
     }
 
     /**

--- a/resources/js/Common/Components/Image.vue
+++ b/resources/js/Common/Components/Image.vue
@@ -7,6 +7,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { Image as ImageProxy } from '@/types/Image'
+import { expandGallery } from '@/Common/Composables/useCompactImage'
 
 const fallbackPath = '/fallback/fallback.svg'
 const DEFAULT_ASPECT_RATIO = 16 / 9
@@ -54,6 +55,8 @@ const props = withDefaults(defineProps<{
 const emits = defineEmits<{
   (e: 'onLoadImage'): void
 }>()
+
+const imageSrc = computed(() => expandGallery(props.src) as ImageProxy | null)
 
 
 const dpr =
@@ -148,9 +151,9 @@ const buildSrcSet = (url?: string, url2x?: string) => {
     .join(', ')
 }
 
-const avif = computed(() => props.srcset?.avif ?? buildSrcSet(props.src?.avif, props.src?.avif_2x))
-const webp = computed(() => props.srcset?.webp ?? buildSrcSet(props.src?.webp, props.src?.webp_2x))
-const original = computed(() => props.srcset?.original ?? buildSrcSet(props.src?.original, props.src?.original_2x))
+const avif = computed(() => props.srcset?.avif ?? buildSrcSet(imageSrc.value?.avif, imageSrc.value?.avif_2x))
+const webp = computed(() => props.srcset?.webp ?? buildSrcSet(imageSrc.value?.webp, imageSrc.value?.webp_2x))
+const original = computed(() => props.srcset?.original ?? buildSrcSet(imageSrc.value?.original, imageSrc.value?.original_2x))
 
 
 
@@ -159,7 +162,7 @@ const defaultSrc = computed(() => {
   const h = responsiveHeights.value.desktop
 
   return buildCFUrl(
-    props.src?.original || fallbackPath,
+    imageSrc.value?.original || fallbackPath,
     props.responsiveEnabled ? w : undefined,
     props.responsiveEnabled ? h : undefined
   )

--- a/resources/js/Common/Composables/useCompactImage.ts
+++ b/resources/js/Common/Composables/useCompactImage.ts
@@ -1,0 +1,37 @@
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 31 Jul 2026 10:00:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+// Compact imgproxy gallery emitted by HasCardWebImages::compactGallery():
+// { _cig: { u: host, b: base64Source }, v: { avif: "sig/proc|.avif", ... } }
+// Reassembles the full url map; passes anything else through untouched.
+
+export interface CompactGallery {
+    _cig: { u: string; b: string }
+    v: Record<string, string>
+}
+
+export function isCompactGallery(value: unknown): value is CompactGallery {
+    return !!value && typeof value === 'object' && '_cig' in (value as object)
+}
+
+export function expandGallery(gallery: any): any {
+    if (!isCompactGallery(gallery)) {
+        return gallery
+    }
+
+    const { u, b } = gallery._cig
+    const out: Record<string, string> = {}
+
+    for (const format in gallery.v) {
+        const raw = gallery.v[format]
+        const splitAt = raw.lastIndexOf('|')
+        const prefix = raw.slice(0, splitAt)
+        const ext = raw.slice(splitAt + 1)
+        out[format] = `${u}/${prefix}/${b}${ext}`
+    }
+
+    return out
+}

--- a/resources/js/Iris/Composables/useStructuredData.ts
+++ b/resources/js/Iris/Composables/useStructuredData.ts
@@ -1,3 +1,5 @@
+import { expandGallery } from "@/Common/Composables/useCompactImage"
+
 export type StructuredDataNode = Record<string, any>
 export type StructuredDataValue = StructuredDataNode | StructuredDataNode[]
 

--- a/resources/js/Iris/Composables/useStructuredData.ts
+++ b/resources/js/Iris/Composables/useStructuredData.ts
@@ -114,8 +114,7 @@ export const generateProductsStructureFromProductsList = ({
             const imageUrl =
                 product.web_images?.main?.original?.original ??
                 product.web_images?.main?.original ??
-                product.web_images?.main?.gallery?.original ??
-                product.web_images?.main?.gallery ??
+                expandGallery(product.web_images?.main?.gallery)?.original ??
                 product.image?.source?.original
 
             if (imageUrl) {
@@ -178,12 +177,10 @@ export const getEntityImageUrls = (entity: Record<string, any> | null | undefine
     const candidates = [
         entity?.web_images?.main?.original?.original,
         entity?.web_images?.main?.original,
-        entity?.web_images?.main?.gallery?.original,
-        entity?.web_images?.main?.gallery,
+        expandGallery(entity?.web_images?.main?.gallery)?.original,
         entity?.web_images?.all?.[0]?.original?.original,
         entity?.web_images?.all?.[0]?.original,
-        entity?.web_images?.all?.[0]?.gallery?.original,
-        entity?.web_images?.all?.[0]?.gallery,
+        expandGallery(entity?.web_images?.all?.[0]?.gallery)?.original,
         entity?.image?.source?.original,
         entity?.image,
     ]


### PR DESCRIPTION
## What

Product card grids (family / sub-department / collection pages) shipped 8 full signed imgproxy URLs per card (~1KB each, 65% of card payload). All variants of one image share the same host and base64 source tail — only the signature, processing segment and extension differ. This PR ships the shared parts once and reassembles URLs in the frontend.

**Backend** (`HasCardWebImages::compactGallery`) emits:
```json
{"_cig": {"u": "https://media.aiku.io", "b": "<base64 source>"},
 "v": {"avif": "<sig>/rs::0:600::|.avif", "webp_2x": "<sig>/rs::0:1200::|.webp", ...}}
```
Any URL that doesn't match the expected shape makes the whole gallery fall back to full URLs.

**Frontend** (`useCompactImage.ts#expandGallery`) reassembles `{u}/{prefix}/{b}{ext}` and passes anything non-compact through untouched. Wired into the two places that consume card galleries:
- `Common/Components/Image.vue` (single choke point for all card components)
- `Iris/Composables/useStructuredData.ts` (reads `gallery.original` directly for SEO JSON-LD — would have silently broken)

## Scope

Only `IrisProductsInWebpageResource` + `IrisAuthenticatedProductsInWebpageResource` (via `getCardWebImages`). Product page galleries, see-also, recommendations, department tiles keep the old full-URL format — the decoder is a no-op for them. Verified both formats coexist on `/aromatherapy/essential-oils/eo` (compact, 225 cards) and `/aromatherapy/essential-oils/eo/eo-03` (old format, zero compact).

## Evidence

- Production family page (awgifts.bg bath-bombs): 1,986 media URLs = 295KB of an 851KB page; 698 in props JSON. Card grids were ~600 of those.
- Per-card gallery: ~1,022 → ~460 bytes. Family-page props shrink ~25-30% (SSR + hydration cost, not just wire — gzip already compressed the repetition).
- PHP round-trip byte-identical against production-style URLs; browser-side reassembled URLs verified loading real images locally.

## Review focus for frontend team

1. Any OTHER direct consumers of `web_images.{main,secondary}.gallery.<format>` on card products that bypass `Image.vue`? (grep for `gallery?.original` / `gallery.avif` etc. — I found and fixed `useStructuredData`, card components all go through `Image.vue`.)
2. `expandGallery` returns `any` — happy to tighten types if you prefer.

## Deploy note

Backend emits compact the moment PHP deploys; the decoder must be in the built iris bundle. If the deploy builds assets before switching the release symlink (normal flow) there is no gap. If assets build after, cards show fallback images for that window.