### PR TITLE
fix: 🌍 keep blocked-country data out of URLs and close JSON bypass on retina geo block

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+        {
+            "name": "vite",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "dev"],
+            "port": 5173
+        }
+    ]
+}

--- a/app/Actions/Iris/Basket/IndexBasketProducts.php
+++ b/app/Actions/Iris/Basket/IndexBasketProducts.php
@@ -14,6 +14,7 @@ use App\Actions\OrgAction;
 use App\Models\Ordering\Order;
 use App\Models\Ordering\Transaction;
 use App\Services\QueryBuilder;
+use Illuminate\Support\Arr;
 
 class IndexBasketProducts extends OrgAction
 {
@@ -54,6 +55,6 @@ class IndexBasketProducts extends OrgAction
             ])
             ->selectRaw("'{$order->currency->code}'  as currency_code")
             ->withPaginator('', tableName: request()->route()->getName())
-            ->withQueryString();
+            ->appends(Arr::except(request()->query(), ['domain', 'website']));
     }
 }

--- a/app/Actions/Iris/Catalogue/FetchFamilyListCustomSorted.php
+++ b/app/Actions/Iris/Catalogue/FetchFamilyListCustomSorted.php
@@ -10,6 +10,7 @@ use App\Enums\Web\Webpage\WebpageSubTypeEnum;
 use App\Models\Catalogue\ProductCategory;
 use App\Models\Web\Webpage;
 use App\Services\QueryBuilder;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Lorisleiva\Actions\ActionRequest;
@@ -60,7 +61,7 @@ class FetchFamilyListCustomSorted extends IrisAction
             ->allowedSorts([ 'code', 'product_categories.created_at', 'name'])
             ->allowedFilters([$globalSearch])
             ->paginate(request('per_page', 100))
-            ->withQueryString();
+            ->appends(Arr::except(request()->query(), ['domain', 'website']));
     }
 
     public function jsonResponse(LengthAwarePaginator $families)

--- a/app/Actions/Iris/Catalogue/IndexIrisCatalogue.php
+++ b/app/Actions/Iris/Catalogue/IndexIrisCatalogue.php
@@ -240,7 +240,7 @@ class IndexIrisCatalogue extends IrisAction
             ->allowedFilters([$globalSearch])
             ->allowedSorts(['code', 'name', ...$additionalSortableKeys])
             ->withPaginator($prefix, tableName: request()->route()->getName())
-            ->withQueryString();
+            ->appends(Arr::except(request()->query(), ['domain', 'website']));
     }
 
     public function tableStructure(string $scope, ?string $parent = null, $prefix = null): Closure

--- a/app/Actions/Web/Website/BlockedCountries/CheckIfCountryRegionsIsBlocked.php
+++ b/app/Actions/Web/Website/BlockedCountries/CheckIfCountryRegionsIsBlocked.php
@@ -22,14 +22,14 @@ class CheckIfCountryRegionsIsBlocked
     public function handle($request): bool
     {
         $isBlocked = false;
-        if ($request->input('has_blocked_country_regions')) {
+        if ($request->attributes->get('has_blocked_country_regions')) {
             $countryFromCloudFlare = $request->header('CF-IPCountry');
-            if ($countryFromCloudFlare && in_array($countryFromCloudFlare, $request->input('blocked_countries'))) {
+            if ($countryFromCloudFlare && in_array($countryFromCloudFlare, $request->attributes->get('blocked_countries', []))) {
                 $ip  = $request->ip();
                 $key = "website-geo-blocked-ips:{$request->input('website')?->id}:$countryFromCloudFlare:$ip";
 
                 $blockedData = Cache::remember($key, 28800, fn () => $this->isBlocked(
-                    Arr::get($request->input('blocked_country_regions'), $countryFromCloudFlare),
+                    Arr::get($request->attributes->get('blocked_country_regions'), $countryFromCloudFlare),
                     $countryFromCloudFlare,
                     $ip
                 ));

--- a/app/Http/Middleware/Concerns/DetectsWebsite.php
+++ b/app/Http/Middleware/Concerns/DetectsWebsite.php
@@ -9,10 +9,19 @@
 namespace App\Http\Middleware\Concerns;
 
 use App\Models\Web\Website;
+use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 
 trait DetectsWebsite
 {
+    public const BLOCKED_COUNTRY_KEYS = ['has_blocked_country_regions', 'blocked_countries', 'blocked_country_regions'];
+
+    public function applyWebsiteData(Request $request, array $websiteData): void
+    {
+        $request->attributes->add(Arr::only($websiteData, self::BLOCKED_COUNTRY_KEYS));
+        $request->merge(Arr::except($websiteData, self::BLOCKED_COUNTRY_KEYS));
+    }
+
     public function getWebsiteBaseData(Website $website): array
     {
         $websiteData = [

--- a/app/Http/Middleware/DetectIrisWebsite.php
+++ b/app/Http/Middleware/DetectIrisWebsite.php
@@ -39,7 +39,7 @@ class DetectIrisWebsite
                 }
             );
         }
-        $request->merge($websiteData);
+        $this->applyWebsiteData($request, $websiteData);
 
         $response = $next($request);
 

--- a/app/Http/Middleware/DetectWebsite.php
+++ b/app/Http/Middleware/DetectWebsite.php
@@ -25,7 +25,7 @@ class DetectWebsite
             abort(404, 'Not found');
         }
 
-        $request->merge($this->getWebsiteBaseData($website));
+        $this->applyWebsiteData($request, $this->getWebsiteBaseData($website));
 
         return $next($request);
     }

--- a/app/Http/Middleware/RestrictCountryRegions.php
+++ b/app/Http/Middleware/RestrictCountryRegions.php
@@ -16,11 +16,6 @@ class RestrictCountryRegions
 {
     public function handle(Request $request, Closure $next)
     {
-
-        if ($request->expectsJson()) {
-            return $next($request);
-        }
-
         $isBlocked = CheckIfCountryRegionsIsBlocked::run($request);
         if ($isBlocked) {
             abort(403);

--- a/routes/retina/web/retina_webhooks.php
+++ b/routes/retina/web/retina_webhooks.php
@@ -18,7 +18,7 @@ use App\Actions\Accounting\TopUpPaymentApiPoint\WebHooks\TopUpPaymentFailure;
 use App\Actions\Accounting\TopUpPaymentApiPoint\WebHooks\TopUpPaymentSuccess;
 use App\Actions\CRM\Prospect\UI\CreateProspectFromWebBlock;
 
-Route::name('webhooks.')->prefix('webhooks')->group(function () {
+Route::name('webhooks.')->prefix('webhooks')->withoutMiddleware(App\Http\Middleware\RestrictCountryRegions::class)->group(function () {
     Route::name('checkout_com.')->prefix('checkout-com')->group(function () {
         Route::get('/greeting', function () {
             return 'Hello World';

--- a/tests/Feature/IrisTest.php
+++ b/tests/Feature/IrisTest.php
@@ -58,10 +58,11 @@ test('it processes blocked country regions in DetectWebsite', function () {
     $middleware = new DetectWebsite();
 
     $middleware->handle($request, function ($req) {
-        expect($req->input('has_blocked_country_regions'))->toBeTrue()
-            ->and($req->input('blocked_countries'))->toHaveCount(2)
-            ->and($req->input('blocked_countries'))->toContain('US', 'GB')
-            ->and($req->input('blocked_country_regions'))->toEqual($this->website->blocked_country_regions);
+        expect($req->attributes->get('has_blocked_country_regions'))->toBeTrue()
+            ->and($req->attributes->get('blocked_countries'))->toHaveCount(2)
+            ->and($req->attributes->get('blocked_countries'))->toContain('US', 'GB')
+            ->and($req->attributes->get('blocked_country_regions'))->toEqual($this->website->blocked_country_regions)
+            ->and($req->query->has('has_blocked_country_regions'))->toBeFalse();
 
         return response('OK');
     });
@@ -107,13 +108,89 @@ test('it processes blocked country regions in DetectIrisWebsite', function () {
     $middleware = new DetectIrisWebsite();
 
     $middleware->handle($request, function ($req) {
-        expect($req->input('has_blocked_country_regions'))->toBeTrue()
-            ->and($req->input('blocked_countries'))->toHaveCount(2)
-            ->and($req->input('blocked_countries'))->toContain('US', 'GB')
-            ->and($req->input('blocked_country_regions'))->toEqual($this->website->blocked_country_regions);
+        expect($req->attributes->get('has_blocked_country_regions'))->toBeTrue()
+            ->and($req->attributes->get('blocked_countries'))->toHaveCount(2)
+            ->and($req->attributes->get('blocked_countries'))->toContain('US', 'GB')
+            ->and($req->attributes->get('blocked_country_regions'))->toEqual($this->website->blocked_country_regions)
+            ->and($req->query->has('has_blocked_country_regions'))->toBeFalse();
 
         return response('OK');
     });
+});
+
+test('it blocks a visitor from a restricted region end to end', function () {
+    $this->website->update([
+        'blocked_country_regions' => [
+            'US' => ['postcode' => '/^100/']
+        ]
+    ]);
+
+    DB::table('ip_geolocations')->updateOrInsert(
+        ['ip' => '5.6.7.8'],
+        [
+            'country'    => 'US',
+            'city'       => 'New York',
+            'postcode'   => '10001',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]
+    );
+
+    DetectWebsiteFromDomain::mock()
+        ->shouldReceive('parseDomain')
+        ->andReturn($this->website->domain);
+
+    $request = Request::create(
+        'http://' . $this->website->domain,
+        'GET',
+        server: ['REMOTE_ADDR' => '5.6.7.8', 'HTTP_CF_IPCOUNTRY' => 'US']
+    );
+
+    $middleware = new DetectIrisWebsite();
+
+    $middleware->handle($request, function ($req) {
+        expect(\App\Actions\Web\Website\BlockedCountries\CheckIfCountryRegionsIsBlocked::run($req))->toBeTrue();
+
+        return response('OK');
+    });
+});
+
+test('it blocks a json request from a restricted region in retina', function () {
+    $this->website->update([
+        'blocked_country_regions' => [
+            'US' => ['postcode' => '/^100/']
+        ]
+    ]);
+
+    DB::table('ip_geolocations')->updateOrInsert(
+        ['ip' => '5.6.7.8'],
+        [
+            'country'    => 'US',
+            'city'       => 'New York',
+            'postcode'   => '10001',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]
+    );
+
+    DetectWebsiteFromDomain::shouldRun()->andReturn($this->website);
+
+    $request = Request::create(
+        'http://' . $this->website->domain . '/app/models/order/1/submit',
+        'PATCH',
+        server: [
+            'REMOTE_ADDR'       => '5.6.7.8',
+            'HTTP_CF_IPCOUNTRY' => 'US',
+            'HTTP_ACCEPT'       => 'application/json',
+            'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest',
+        ]
+    );
+
+    $detect = new DetectWebsite();
+    $restrict = new App\Http\Middleware\RestrictCountryRegions();
+
+    expect(fn () => $detect->handle($request, fn ($req) => $restrict->handle($req, fn () => response('OK'))))
+        ->toThrow(Symfony\Component\HttpKernel\Exception\HttpException::class);
 });
 
 test('it logs firewall blocked country events fetched from Cloudflare', function () {


### PR DESCRIPTION
## Problem
Production URLs on ancientwisdom.biz intermittently show `?has_blocked_country_regions=0`, e.g. on product pages, even though no country restrictions are configured there.

## Root cause
`DetectIrisWebsite`/`DetectWebsite` inject website data with `\$request->merge()`. On a GET request that writes straight into the query-parameter bag, so anything that rebuilds URLs from `request()->query()` leaks it:
- the 301 redirect builder in `ShowIrisWebpage` (its except-list strips `website`/`domain` but never got the blocked-country keys) — Varnish then caches those polluted redirects for up to 10 days, hence the intermittent sightings
- `withQueryString()` paginators in Iris catalogue/basket, which leak `domain=` and a serialized `website[...]` model on **all** websites

The flag is `0` because AW's `blocked_country_regions` column holds leftover entries with no cities/postcodes.

## Changes
- Blocked-country data (`has_blocked_country_regions`, `blocked_countries`, `blocked_country_regions`) now travels in `\$request->attributes` (server-only, can never serialize into a URL and can no longer be spoofed from the query string). `website`/`domain` stay merged since ~40 call sites read `input('website')`.
- `CheckIfCountryRegionsIsBlocked` reads from attributes.
- The three Iris paginators use `appends(Arr::except(request()->query(), ['domain', 'website']))` instead of `withQueryString()`, so real visitor params (page, filters) still propagate but middleware-injected data doesn't.
- `RestrictCountryRegions` no longer skips `expectsJson()` requests — that skip let a blocked visitor bypass the retina 403 (including order submission) by sending `Accept: application/json`. Payment webhooks are now exempted explicitly via `withoutMiddleware` instead.

## Tests
- Existing middleware tests updated to assert attributes and a clean query bag
- New end-to-end test: CF-IPCountry header → middleware → `CheckIfCountryRegionsIsBlocked` returns blocked
- New test: JSON-accepting request from a blocked region still gets 403 in retina

All 9 IrisTest tests pass. No behavior or performance change for websites without blocked countries (the check is a single null attribute read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)