### PR TITLE
🛡️ fix: public endpoints 500 on malformed ids, and search terms are literal text not patterns

### DIFF
--- a/app/Actions/Catalogue/Product/Json/GetIrisLastOrderedProducts.php
+++ b/app/Actions/Catalogue/Product/Json/GetIrisLastOrderedProducts.php
@@ -92,7 +92,7 @@ class GetIrisLastOrderedProducts extends IrisAction
     }
 
     /** What this shop sold from this family, one purchase per product per date. */
-    private function getShopCandidates(ProductCategory $productCategory, ?string $ignoredProductId): Collection
+    private function getShopCandidates(ProductCategory $productCategory, ?int $ignoredProductId): Collection
     {
         $query = DB::table('transactions')
             ->selectRaw('DISTINCT ON (products.id, transactions.date::date) products.id as product_id, products.code, products.name, products.web_images, webpages.canonical_url, transactions.date as submitted_at')
@@ -107,7 +107,7 @@ class GetIrisLastOrderedProducts extends IrisAction
     }
 
     /** What the other shops sold of the same products, put back on this shop's products. */
-    private function getMasterShopCandidates(ProductCategory $productCategory, ?string $ignoredProductId): Collection
+    private function getMasterShopCandidates(ProductCategory $productCategory, ?int $ignoredProductId): Collection
     {
         $query = DB::table('invoice_transactions')
             ->selectRaw('DISTINCT ON (products.id, invoice_transactions.date::date) products.id as product_id, products.code, products.name, products.web_images, webpages.canonical_url, invoice_transactions.date as submitted_at')
@@ -129,7 +129,7 @@ class GetIrisLastOrderedProducts extends IrisAction
     }
 
     /** What every shop in the group sold of the same trade unit, put back on this shop's products. */
-    private function getGroupCandidates(ProductCategory $productCategory, ?string $ignoredProductId): Collection
+    private function getGroupCandidates(ProductCategory $productCategory, ?int $ignoredProductId): Collection
     {
         $query = DB::table('invoice_transactions')
             ->selectRaw('DISTINCT ON (products.id, invoice_transactions.date::date) products.id as product_id, products.code, products.name, products.web_images, webpages.canonical_url, invoice_transactions.date as submitted_at')
@@ -163,7 +163,7 @@ class GetIrisLastOrderedProducts extends IrisAction
     }
 
     /** Numbers the purchases of each product, and keeps a few purchases of each recent date. */
-    private function fetchCandidates(Builder $query, ?string $ignoredProductId): Collection
+    private function fetchCandidates(Builder $query, ?int $ignoredProductId): Collection
     {
         if ($ignoredProductId) {
             $query->where('products.id', '!=', $ignoredProductId);
@@ -289,7 +289,7 @@ class GetIrisLastOrderedProducts extends IrisAction
     public function rules(): array
     {
         return [
-            'ignoredProductId' => ['sometimes', 'string'],
+            'ignoredProductId' => ['sometimes', 'integer'],
         ];
     }
 

--- a/app/Providers/MacroServiceProvider.php
+++ b/app/Providers/MacroServiceProvider.php
@@ -53,13 +53,19 @@ class MacroServiceProvider extends ServiceProvider
             return $tableBuilder->applyTo($this);
         });
 
-        Builder::macro('whereAnyWordStartWith', function (string $column, string|array $value): Builder {
+        $quoteAsRegexLiteral = static function (string $value): string {
+            return DB::connection()->getPdo()->quote(
+                preg_replace('/[\\\\^$.\[\]|()*+?{}]/', '\\\\$0', $value)
+            );
+        };
+
+        Builder::macro('whereAnyWordStartWith', function (string $column, string|array $value) use ($quoteAsRegexLiteral): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
 
             /** @var Builder $this */
-            $quotedValue = DB::connection()->getPdo()->quote($value);
+            $quotedValue = $quoteAsRegexLiteral($value);
 
             return $this->where(DB::raw("extensions.remove_accents(".$column.")  COLLATE \"C\""), '~*', DB::raw("('\y' ||  extensions.remove_accents($quotedValue) ||   '.*\y')"))
                 ->orWhereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$value.'%');
@@ -92,12 +98,12 @@ class MacroServiceProvider extends ServiceProvider
             return $this->whereRaw("$column COLLATE \"C\" ILIKE ?", "%".$value.'%');
         });
 
-        Builder::macro('orWhereAnyWordStartWith', function (string $column, string|array $value): Builder {
+        Builder::macro('orWhereAnyWordStartWith', function (string $column, string|array $value) use ($quoteAsRegexLiteral): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
             /** @var Builder $this */
-            $quotedValue = DB::connection()->getPdo()->quote($value);
+            $quotedValue = $quoteAsRegexLiteral($value);
 
             return $this->orWhere(DB::raw("extensions.remove_accents(".$column.")  COLLATE \"C\""), '~*', DB::raw("('\y' ||  extensions.remove_accents($quotedValue) ||   '.*\y')"))
                 ->orWhereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$value.'%');

--- a/app/Providers/MacroServiceProvider.php
+++ b/app/Providers/MacroServiceProvider.php
@@ -59,7 +59,11 @@ class MacroServiceProvider extends ServiceProvider
             );
         };
 
-        Builder::macro('whereAnyWordStartWith', function (string $column, string|array $value) use ($quoteAsRegexLiteral): Builder {
+        $escapeLikeWildcards = static function (string $value): string {
+            return str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $value);
+        };
+
+        Builder::macro('whereAnyWordStartWith', function (string $column, string|array $value) use ($quoteAsRegexLiteral, $escapeLikeWildcards): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
@@ -68,37 +72,37 @@ class MacroServiceProvider extends ServiceProvider
             $quotedValue = $quoteAsRegexLiteral($value);
 
             return $this->where(DB::raw("extensions.remove_accents(".$column.")  COLLATE \"C\""), '~*', DB::raw("('\y' ||  extensions.remove_accents($quotedValue) ||   '.*\y')"))
-                ->orWhereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$value.'%');
+                ->orWhereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$escapeLikeWildcards($value).'%');
         });
 
-        Builder::macro('whereStartWith', function (string $column, string|array $value): Builder {
+        Builder::macro('whereStartWith', function (string $column, string|array $value) use ($escapeLikeWildcards): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
 
             /** @var Builder $this */
-            return $this->whereRaw("$column COLLATE \"C\" ILIKE ?", $value.'%');
+            return $this->whereRaw("$column COLLATE \"C\" ILIKE ?", $escapeLikeWildcards($value).'%');
         });
 
-        Builder::macro('whereEndWith', function (string $column, string|array $value): Builder {
+        Builder::macro('whereEndWith', function (string $column, string|array $value) use ($escapeLikeWildcards): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
 
             /** @var Builder $this */
-            return $this->whereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$value);
+            return $this->whereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$escapeLikeWildcards($value));
         });
 
-        Builder::macro('whereWith', function (string $column, string|array $value): Builder {
+        Builder::macro('whereWith', function (string $column, string|array $value) use ($escapeLikeWildcards): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
 
             /** @var Builder $this */
-            return $this->whereRaw("$column COLLATE \"C\" ILIKE ?", "%".$value.'%');
+            return $this->whereRaw("$column COLLATE \"C\" ILIKE ?", "%".$escapeLikeWildcards($value).'%');
         });
 
-        Builder::macro('orWhereAnyWordStartWith', function (string $column, string|array $value) use ($quoteAsRegexLiteral): Builder {
+        Builder::macro('orWhereAnyWordStartWith', function (string $column, string|array $value) use ($quoteAsRegexLiteral, $escapeLikeWildcards): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
@@ -106,34 +110,34 @@ class MacroServiceProvider extends ServiceProvider
             $quotedValue = $quoteAsRegexLiteral($value);
 
             return $this->orWhere(DB::raw("extensions.remove_accents(".$column.")  COLLATE \"C\""), '~*', DB::raw("('\y' ||  extensions.remove_accents($quotedValue) ||   '.*\y')"))
-                ->orWhereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$value.'%');
+                ->orWhereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$escapeLikeWildcards($value).'%');
         });
 
-        Builder::macro('orWhereStartWith', function (string $column, string|array $value): Builder {
+        Builder::macro('orWhereStartWith', function (string $column, string|array $value) use ($escapeLikeWildcards): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
 
             /** @var Builder $this */
-            return $this->orWhereRaw("$column COLLATE \"C\" ILIKE ?", $value.'%');
+            return $this->orWhereRaw("$column COLLATE \"C\" ILIKE ?", $escapeLikeWildcards($value).'%');
         });
 
-        Builder::macro('orWhereEndWith', function (string $column, string|array $value): Builder {
+        Builder::macro('orWhereEndWith', function (string $column, string|array $value) use ($escapeLikeWildcards): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
 
             /** @var Builder $this */
-            return $this->orWhereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$value);
+            return $this->orWhereRaw("$column COLLATE \"C\" ILIKE ?", '%'.$escapeLikeWildcards($value));
         });
 
-        Builder::macro('orWhereWith', function (string $column, string|array $value): Builder {
+        Builder::macro('orWhereWith', function (string $column, string|array $value) use ($escapeLikeWildcards): Builder {
             if (is_array($value)) {
                 $value = implode(' ', $value);
             }
 
             /** @var Builder $this */
-            return $this->orWhereRaw("$column COLLATE \"C\" ILIKE ?", "%".$value.'%');
+            return $this->orWhereRaw("$column COLLATE \"C\" ILIKE ?", "%".$escapeLikeWildcards($value).'%');
         });
 
 

--- a/routes/iris/json.php
+++ b/routes/iris/json.php
@@ -78,7 +78,7 @@ Route::middleware(["iris-relax-auth:retina"])->group(function () {
     Route::get('canonical-redirect', GetRedirectUrl::class)->name('canonical_redirect');
 
     Route::get('product-last-seen/{webpage:id}', GetIrisProductLastSeen::class)->name('product_last_seen.index')->withoutScopedBindings()->whereNumber('webpage');
-    Route::post('product-last-seen/{webpage:id}', StoreIrisProductLastSeen::class)->name('product_last_seen.store')->withoutScopedBindings();
+    Route::post('product-last-seen/{webpage:id}', StoreIrisProductLastSeen::class)->name('product_last_seen.store')->withoutScopedBindings()->whereNumber('webpage');
     Route::get('product/{product:id}/alternatives', GetIrisProductAlternatives::class)->name('product.alternatives')->withoutScopedBindings()->whereNumber('product');
     Route::get('product-trends', GetIrisProductTrends::class)->name('product_trends.index');
 
@@ -124,9 +124,9 @@ Route::middleware(["iris-relax-auth:retina"])->group(function () {
 
     // Reviews
     Route::get('reviews', GetReviews::class)->name('reviews.index');
-    Route::get('shop/{shop:id}/reviews', [GetReviewableReviews::class, 'inShop'])->name('reviews.shop.show');
-    Route::get('product/{product:id}/reviews', [GetReviewableReviews::class, 'inProduct'])->name('reviews.product.show')->withoutScopedBindings();
-    Route::get('product-category/{productCategory:id}/reviews', [GetReviewableReviews::class, 'inProductCategory'])->name('reviews.product_category.show');
+    Route::get('shop/{shop:id}/reviews', [GetReviewableReviews::class, 'inShop'])->name('reviews.shop.show')->whereNumber('shop');
+    Route::get('product/{product:id}/reviews', [GetReviewableReviews::class, 'inProduct'])->name('reviews.product.show')->withoutScopedBindings()->whereNumber('product');
+    Route::get('product-category/{productCategory:id}/reviews', [GetReviewableReviews::class, 'inProductCategory'])->name('reviews.product_category.show')->whereNumber('productCategory');
     Route::get('product/{product:id}/reviews-third-party', FetchProductReviewThirdParty::class)->name('reviews.third_party.product_review')->whereNumber('product');
 
     // Families Custom Sort
@@ -136,6 +136,6 @@ Route::middleware(["iris-relax-auth:retina"])->group(function () {
     Route::get('{productCategory}/family-under-department', GetFamiliesUnderDepartmentPage::class)->name('website.category.family_under_department');
 
     Route::get('{webpage:slug}/reviews', FetchIrisReviewsInWebpage::class)->name('fetch_reviews');
-    Route::get('reviews/{webpage:id}', GetIrisReviews::class)->name('fetch_reviews_new');
+    Route::get('reviews/{webpage:id}', GetIrisReviews::class)->name('fetch_reviews_new')->whereNumber('webpage');
 
 });

--- a/routes/iris/models.php
+++ b/routes/iris/models.php
@@ -14,7 +14,6 @@ use App\Actions\Iris\CRM\DeleteIrisBackInStockReminder;
 use App\Actions\Iris\CRM\DeleteIrisPortfolioFavourites;
 use App\Actions\Iris\CRM\StoreIrisBackInStockReminder;
 use App\Actions\Iris\CRM\StoreIrisFavourites;
-use App\Actions\Iris\CRM\StoreIrisProductLastSeen;
 use App\Actions\Iris\CRM\UpdateIrisCustomer;
 use App\Actions\Iris\Portfolio\DeleteIrisPortfolioFromMultiChannels;
 use App\Actions\Iris\Portfolio\StoreIrisPortfolioToAllChannels;
@@ -57,7 +56,7 @@ Route::post('{transaction:id}/update-transaction', UpdateEcomBasketTransaction::
 Route::post('remind-back-in-stock/{product:id}', StoreIrisBackInStockReminder::class)->name('remind_back_in_stock.store')->withoutScopedBindings()->whereNumber('product');
 Route::delete('remind-back-in-stock/{product:id}', DeleteIrisBackInStockReminder::class)->name('remind_back_in_stock.delete')->withoutScopedBindings()->whereNumber('product');
 
-Route::post('review/{review:id}/react', ReactRetinaReview::class)->name('review.react');
+Route::post('review/{review:id}/react', ReactRetinaReview::class)->name('review.react')->whereNumber('review');
 
 Route::name('order.')->prefix('order/{order:id}')->whereNumber('order')->group(function () {
     Route::patch('update-gr-gift', UpdateRetinaOrderGrGift::class)->name('update_gr_gift');

--- a/tests/Unit/IrisRouteBindingsTest.php
+++ b/tests/Unit/IrisRouteBindingsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Sun, 02 Aug 2026 20:30:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Support\Facades\Route;
+
+test('public iris routes binding on id only accept numbers', function () {
+    $unguarded = collect(Route::getRoutes()->getRoutes())
+        ->filter(fn ($route) => str_starts_with((string)$route->getName(), 'iris.'))
+        ->flatMap(function ($route) {
+            return collect($route->bindingFields())
+                ->filter(fn ($field) => $field === 'id')
+                ->keys()
+                ->reject(fn ($parameter) => ($route->wheres[$parameter] ?? null) === '[0-9]+')
+                ->map(fn ($parameter) => $route->getName().' -> {'.$parameter.'}');
+        });
+
+    expect($unguarded->all())->toBe([]);
+});

--- a/tests/Unit/LikeWildcardEscapingTest.php
+++ b/tests/Unit/LikeWildcardEscapingTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Sun, 02 Aug 2026 23:00:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use App\Models\Catalogue\Product;
+
+test('a lone wildcard no longer matches every row', function (string $macro) {
+    $everything = Product::count();
+
+    expect($everything)->toBeGreaterThan(1);
+
+    $matches = Product::where(fn ($query) => $query->{$macro}('products.name', '%'))->count();
+
+    expect($matches)->toBeLessThan($everything);
+})->with(['whereWith', 'whereStartWith', 'whereEndWith', 'whereAnyWordStartWith']);
+
+test('an underscore matches an underscore, not any character', function () {
+    $product = Product::first();
+    $probe   = mb_substr($product->name, 0, 1).'_'.mb_substr($product->name, 2, 1);
+
+    $matches = Product::where(fn ($query) => $query->whereWith('products.name', $probe))->count();
+
+    expect($matches)->toBe(
+        Product::where('products.name', 'ILIKE', '%'.str_replace('_', '\_', $probe).'%')->count()
+    );
+});
+
+test('ordinary search terms still match', function () {
+    $product = Product::first();
+
+    expect($product)->not->toBeNull();
+
+    $found = Product::where(fn ($query) => $query->whereWith('products.name', $product->name))
+        ->where('products.id', $product->id)
+        ->exists();
+
+    expect($found)->toBeTrue();
+});

--- a/tests/Unit/WhereAnyWordStartWithTest.php
+++ b/tests/Unit/WhereAnyWordStartWithTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Sun, 02 Aug 2026 21:00:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use App\Models\Catalogue\Product;
+
+test('search terms with regex metacharacters do not break the query', function (string $term) {
+    expect(Product::where(fn ($query) => $query->whereAnyWordStartWith('products.name', $term))->count())
+        ->toBeInt();
+})->with([
+    'unbalanced parenthesis'  => 'rose (large',
+    'windows path'            => 'C:\WINDOWS\system32\drivers\etc\hosts',
+    'traversal'               => '../329289',
+    'quantifier'              => 'a{2,',
+    'character class'         => 'tea [green]',
+    'alternation and anchors' => '^rose|jasmine$',
+    'star and plus'           => '**+?',
+]);
+
+test('escaping keeps the search matching real words', function () {
+    $product = Product::first();
+
+    expect($product)->not->toBeNull();
+
+    $found = Product::where(fn ($query) => $query->whereAnyWordStartWith('products.name', $product->name))
+        ->where('products.id', $product->id)
+        ->exists();
+
+    expect($found)->toBeTrue();
+});


### PR DESCRIPTION
Two fixes for public endpoints that returned 500s on malformed input. Both were found while checking Sentry and NightOwl after today's deploys. Neither is a regression from those deploys — both are long-standing.

## 1. `id` endpoints 500 instead of 404

Six Iris routes bind `{model:id}` with no numeric constraint, so a non-numeric path segment reached Postgres as an integer bind and threw `QueryException`. Scanner traffic between 06:00–08:00 turned this into ~1,900 Sentry events.

| Route | File |
|---|---|
| `product_last_seen.store` | `routes/iris/json.php:81` |
| `reviews.shop.show`, `reviews.product.show`, `reviews.product_category.show` | `routes/iris/json.php:127-129` |
| `fetch_reviews_new` | `routes/iris/json.php:139` |
| `review.react` | `routes/iris/models.php:60` |

Line 80 already had `whereNumber` and line 81 did not, on the same endpoint, so this was drift rather than intent.

Also `GetIrisLastOrderedProducts::rules()` validated `ignoredProductId` as `string`, letting a raw string reach a `where` against a `bigint` column — the source of `products.id != ../329289`. Now `integer`, with the four `?string` hints corrected to `?int`.

Side benefit: that param was concatenated into the cache key (`iris:last_ordered_products:%s:%s`), so arbitrary strings could mint unlimited cache entries. Bounding it to integers closes that too.

## 2. Search terms parsed as regex

`Builder::whereAnyWordStartWith` interpolates the user's search term into Postgres's `~*` operator. Any regex metacharacter throws. The value was already PDO-quoted so nothing injected, but `rose (large` or `C:\WINDOWS\system32` produced `SQLSTATE[2201B]`.

Fixed with one shared escape closure used by both `whereAnyWordStartWith` and `orWhereAnyWordStartWith` — the only two macros feeding input into `~*`. All 278 call sites inherit it.

**Behaviour change:** searches containing metacharacters used to 500 and now return literal matches.

## Tests

- `tests/Unit/IrisRouteBindingsTest.php` sweeps all 126 `iris.*` routes and fails on any `:id` binding without a numeric constraint, naming the offender.
- `tests/Unit/WhereAnyWordStartWithTest.php` drives the real Sentry payloads through Postgres. With the escape removed, 4 of 8 fail, reproducing the production errors verbatim (`parentheses () not balanced`, `invalid escape \ sequence`, `invalid repetition count(s)`, `quantifier operand invalid`). One test also proves a real product name still matches itself, so this is not "no crash, no results".

Verified both tests fail without their fix. `AccountingTest` 98/98 (1,611 assertions) as the regression check for the shared macro, since it has the most index-filter coverage. Pint clean.

`IrisTest` has 3 failures in `FetchFirewallBlockedCountryEvents` (Cloudflare) — pre-existing, identical count on a clean tree, untouched here.

## 3. ILIKE wildcards treated as wildcards

Every one of these macros pairs its regex clause with an `ILIKE` clause, and the term went into that pattern unescaped. Searching `%` matched every row in the table; `50%` was far broader than intended. Never threw, so it produced no Sentry events — it silently returned wrong results.

`%`, `_` and `\` are now escaped across all eight builders (`whereStartWith`, `whereEndWith`, `whereWith`, `whereAnyWordStartWith` and their `orWhere` twins) via one shared closure, the same shape as the regex one. Backslash is escaped first so the backslashes introduced when escaping `%` and `_` are not doubled again.

**Deliberate behaviour change, signed off by Raul:** `_` is currently a single-character wildcard, so `ABC_123` also matches `ABC-123`. It now matches only a literal `ABC_123`. Codes containing underscores will return narrower results. This is the correct reading of what a user typed, and the accidental fuzziness was not intentional.

Tests in `tests/Unit/LikeWildcardEscapingTest.php`: a lone `%` no longer returns the whole table across all four `where*` macros; an underscore probe matches exactly what a manually-escaped ILIKE matches; ordinary terms still match. Reverting the escape fails 5 of 6.

## Review notes

Each of the three commits is independently revertible; they share `MacroServiceProvider.php` only between commits 2 and 3.

Regression check for the shared macro is `AccountingTest` (98 tests, 1,611 assertions), the suite with the most index-filter coverage — green after each commit. Every fix here was confirmed to fail its own test when reverted, rather than only passing once written.

The one behaviour change a reviewer should weigh is the underscore case above; everything else only changes what happens to input that previously errored or silently over-matched.

