### PR TITLE
🩹 fix: picking-session DN query and uninitialised user in magic pick

### DIFF
--- a/app/Actions/Dispatching/DeliveryNoteItem/UI/IndexDeliveryNoteItemsInPickingSessionGrouped.php
+++ b/app/Actions/Dispatching/DeliveryNoteItem/UI/IndexDeliveryNoteItemsInPickingSessionGrouped.php
@@ -41,7 +41,9 @@ class IndexDeliveryNoteItemsInPickingSessionGrouped extends OrgAction
             $query->where('delivery_notes.id', $deliveryNoteId);
         }
 
-        $query->where('delivery_note_items.quantity_required', '>', 0);
+        $query->whereHas('deliveryNoteItems', function ($query) {
+            $query->where('quantity_required', '>', 0);
+        });
 
         return $query
             ->select([

--- a/app/Actions/Dispatching/Picking/PickFromMagicPlace.php
+++ b/app/Actions/Dispatching/Picking/PickFromMagicPlace.php
@@ -35,7 +35,7 @@ class PickFromMagicPlace extends OrgAction
     use AutoIgnoreZeroQuantityItems;
 
     private DeliveryNoteItem $deliveryNoteItem;
-    protected User $user;
+    protected ?User $user = null;
 
     public function handle(DeliveryNoteItem $deliveryNoteItem, array $modelData): ?Picking
     {


### PR DESCRIPTION
Two regressions introduced by #2520, both currently red on main CI (run 30946653942):

- `IndexDeliveryNoteItemsInPickingSessionGrouped` filtered a `delivery_notes` query on `delivery_note_items.quantity_required` without joining that table → `missing FROM-clause entry` QueryException on every picking-session DN listing. Replaced with `whereHas`.
- `PickFromMagicPlace::$user` is a typed property that is never set when the action runs via `run()`, so `ignoreZeroQuantityItems(..., $this->user)` throws "must not be accessed before initialization". Made it nullable with a null default, matching `StorePicking`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)