### PR TITLE
💰 feat: Marketing attribution Phase 6 — ad spend import, ROAS and CAC

### DIFF
--- a/app/Actions/CRM/Customer/MatchCustomerProspects.php
+++ b/app/Actions/CRM/Customer/MatchCustomerProspects.php
@@ -9,6 +9,8 @@
 namespace App\Actions\CRM\Customer;
 
 use App\Actions\CRM\Prospect\UpdateProspect;
+use App\Actions\CRM\TrafficSource\MergeTrafficSourceTouchHistories;
+use App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution;
 use App\Actions\OrgAction;
 use App\Actions\Traits\WithActionUpdate;
 use App\Enums\CRM\Prospect\ProspectFailStatusEnum;
@@ -48,6 +50,9 @@ class MatchCustomerProspects extends OrgAction
             }
 
 
+            /* strict: false is load-bearing: customer_id is only an accepted field on the non-strict
+               rules, so the strict default silently discarded the link while still marking the
+               prospect registered. */
             UpdateProspect::make()->action(
                 $prospect,
                 [
@@ -57,8 +62,24 @@ class MatchCustomerProspects extends OrgAction
                     'fail_status'   => ProspectFailStatusEnum::NA,
                     'registered_at' => $customer->created_at,
                     'invoiced_at'   => $fistInvoice?->created_at,
-                ]
+                ],
+                strict: false
             );
+
+            /* The prospect's touches live only on the prospect row: a mailshot click is recorded
+               server-side and never reaches the browser cookie the registration captured. Without
+               merging them into the customer's history here, the mailshot that produced this
+               registration would get no credit for it. */
+            if (filled($prospect->traffic_sources)) {
+                $customer->update([
+                    'traffic_sources' => MergeTrafficSourceTouchHistories::run(
+                        $prospect->traffic_sources,
+                        $customer->traffic_sources
+                    ),
+                ]);
+
+                RecalculateTrafficSourceAttribution::run($customer->fresh());
+            }
         }
 
 

--- a/app/Actions/CRM/Customer/MatchCustomerProspects.php
+++ b/app/Actions/CRM/Customer/MatchCustomerProspects.php
@@ -71,14 +71,20 @@ class MatchCustomerProspects extends OrgAction
                merging them into the customer's history here, the mailshot that produced this
                registration would get no credit for it. */
             if (filled($prospect->traffic_sources)) {
-                $customer->update([
-                    'traffic_sources' => MergeTrafficSourceTouchHistories::run(
-                        $prospect->traffic_sources,
-                        $customer->traffic_sources
-                    ),
-                ]);
+                /* Runs synchronously inside the registration request; attribution bookkeeping must
+                   never be the reason a registration fails. */
+                try {
+                    $customer->update([
+                        'traffic_sources' => MergeTrafficSourceTouchHistories::run(
+                            $prospect->traffic_sources,
+                            $customer->traffic_sources
+                        ),
+                    ]);
 
-                RecalculateTrafficSourceAttribution::run($customer->fresh());
+                    RecalculateTrafficSourceAttribution::run($customer->fresh());
+                } catch (\Throwable $e) {
+                    report($e);
+                }
             }
         }
 

--- a/app/Actions/CRM/Customer/StoreCustomer.php
+++ b/app/Actions/CRM/Customer/StoreCustomer.php
@@ -100,7 +100,10 @@ class StoreCustomer extends OrgAction
         );
 
         $emailSubscriptionsData = Arr::pull($modelData, 'email_subscriptions', []);
-        $trafficSourcesData     = Arr::pull($modelData, 'traffic_sources');
+        /* Deliberately get, not pull: the raw touch history must persist on the customer row. It is
+           the source of truth every attribution recalculation rebuilds from - pivots built here but
+           never backed by the column would be silently destroyed by the first recalculation. */
+        $trafficSourcesData     = Arr::get($modelData, 'traffic_sources');
 
         $customer = DB::transaction(function () use ($shop, $modelData, $contactAddressData, $deliveryAddressData, $taxNumberData, $emailSubscriptionsData) {
             /** @var Customer $customer */

--- a/app/Actions/CRM/Customer/StoreCustomer.php
+++ b/app/Actions/CRM/Customer/StoreCustomer.php
@@ -182,7 +182,14 @@ class StoreCustomer extends OrgAction
         }
 
         if ($trafficSourcesData) {
-            $this->processTrafficSources($customer, $trafficSourcesData);
+            /* Attribution is bookkeeping; it must never fail a registration. The customer row is
+               already committed, so an exception here would 500 the response and the retry would
+               hit "email already taken". */
+            try {
+                $this->processTrafficSources($customer, $trafficSourcesData);
+            } catch (Throwable $e) {
+                report($e);
+            }
         }
 
         if ($customer->shop->is_aiku) {

--- a/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
+++ b/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
@@ -20,13 +20,18 @@ class AttachTrafficSourcesToModel
     use AsAction;
 
     /**
-     * Resolves the parsed marketing touches into shop traffic sources and campaigns and syncs the
-     * calculated attribution share onto the given model's `trafficSources` morph-to-many relationship.
+     * Resolves the parsed marketing touches into shop traffic sources and campaigns and writes the
+     * calculated attribution shares onto the model's `trafficSources` pivot, one row per
+     * (source, campaign) pair, so a customer who engaged with two campaigns of the same source keeps
+     * both credited separately and per-campaign reporting sees them. Shares across all rows of a
+     * model still sum to 1.0.
      *
-     * `model_has_traffic_sources` holds at most one row per (model, traffic source), so the per-campaign
-     * shares returned by the attribution model are summed back up per traffic source before being written.
-     * Without this the second campaign of a source would overwrite the first and the model would end up
-     * carrying only a fraction of the credit it was actually awarded.
+     * A campaign reference seen in a touch with no matching campaign row creates one, so the campaign
+     * ids that ad platforms put in landing URLs become reportable entities the moment the first
+     * visitor arrives with one, and cost imports have something to match against.
+     *
+     * Every caller runs against a model with no pivot rows for these touches (fresh registration,
+     * order submit, or a recalculation that detached first), so rows are inserted, never merged.
      *
      * @param array<int, array{timestamp: int|null, abbr: string, type: \App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum, campaign_ref: string|null}> $touches
      */
@@ -54,7 +59,7 @@ class AttachTrafficSourcesToModel
             return;
         }
 
-        $pivots = [];
+        $touchedSourceIds = [];
 
         foreach ($shares as $share) {
             /** @var TrafficSource|null $trafficSource */
@@ -64,38 +69,40 @@ class AttachTrafficSourcesToModel
                 continue;
             }
 
-            $campaignId = null;
-            if ($share['campaign_ref']) {
-                $campaignId = TrafficSourceCampaign::where('traffic_source_id', $trafficSource->id)
-                    ->where('reference', $share['campaign_ref'])
-                    ->value('id');
-            }
+            $model->trafficSources()->attach($trafficSource->id, [
+                'share'                      => round($share['share'], 2),
+                'traffic_source_campaign_id' => $share['campaign_ref']
+                    ? $this->resolveCampaignId($trafficSource, $share['campaign_ref'])
+                    : null,
+                'attribution_model'          => $attributionModel,
+            ]);
 
-            if (!isset($pivots[$trafficSource->id])) {
-                $pivots[$trafficSource->id] = [
-                    'share'                      => 0.0,
-                    'traffic_source_campaign_id' => $campaignId,
-                    'attribution_model'          => $attributionModel,
-                ];
-            } elseif ($pivots[$trafficSource->id]['traffic_source_campaign_id'] !== $campaignId) {
-                $pivots[$trafficSource->id]['traffic_source_campaign_id'] = null;
-            }
-
-            $pivots[$trafficSource->id]['share'] += $share['share'];
+            $touchedSourceIds[$trafficSource->id] = true;
         }
 
-        if (empty($pivots)) {
-            return;
-        }
-
-        foreach ($pivots as $trafficSourceId => $pivot) {
-            $pivots[$trafficSourceId]['share'] = round($pivot['share'], 2);
-        }
-
-        $model->trafficSources()->syncWithoutDetaching($pivots);
-
-        foreach ($trafficSources->whereIn('id', array_keys($pivots)) as $trafficSource) {
+        foreach ($trafficSources->whereIn('id', array_keys($touchedSourceIds)) as $trafficSource) {
             TrafficSourceHydrateCustomers::dispatch($trafficSource);
+        }
+    }
+
+    private function resolveCampaignId(TrafficSource $trafficSource, string $reference): ?int
+    {
+        try {
+            return TrafficSourceCampaign::firstOrCreate(
+                [
+                    'traffic_source_id' => $trafficSource->id,
+                    'reference'         => $reference,
+                ],
+                [
+                    'name' => $reference,
+                    'type' => $trafficSource->type,
+                ]
+            )->id;
+        } catch (\Throwable) {
+            /* `reference` is globally unique: the same ad-platform campaign id appearing under a
+               different shop's source cannot create a second row. The touch keeps its source-level
+               share; only the campaign breakdown is unavailable for it. */
+            return null;
         }
     }
 }

--- a/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
+++ b/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
@@ -88,6 +88,23 @@ class AttachTrafficSourcesToModel
     private function resolveCampaignId(TrafficSource $trafficSource, string $reference): ?int
     {
         try {
+            $campaignId = TrafficSourceCampaign::where('traffic_source_id', $trafficSource->id)
+                ->where('reference', $reference)
+                ->value('id');
+
+            if ($campaignId) {
+                return $campaignId;
+            }
+
+            /* Touch strings originate in client-controlled cookies, so auto-creation is limited to
+               references shaped like the numeric campaign ids ad platforms actually issue. Anything
+               else (including the mailshot-N refs, which the click pipeline creates server-side with
+               a proper name) must already exist to be credited; otherwise a visitor cycling made-up
+               references could mint unlimited campaign rows named whatever they like. */
+            if (!preg_match('/^\d{1,20}$/', $reference)) {
+                return null;
+            }
+
             return TrafficSourceCampaign::firstOrCreate(
                 [
                     'traffic_source_id' => $trafficSource->id,

--- a/app/Actions/CRM/TrafficSource/GetShopEmailMarketingPerformance.php
+++ b/app/Actions/CRM/TrafficSource/GetShopEmailMarketingPerformance.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+use App\Actions\Helpers\CurrencyExchange\GetCurrencyExchange;
+use App\Enums\Comms\Mailshot\MailshotTypeEnum;
+use App\Models\Catalogue\Shop;
+use App\Models\Comms\Mailshot;
+use App\Models\CRM\TrafficSourceCampaign;
+use App\Models\Helpers\Currency;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetShopEmailMarketingPerformance
+{
+    use AsAction;
+
+    /**
+     * Answers, per mailshot and in total, whether the emails a shop sends earn sales or just annoy
+     * people: delivery/open/click/unsubscribe engagement from the mailshot stats, an estimated send
+     * cost from the SES per-message price, and the share-weighted revenue and customers attributed to
+     * each mailshot's click touchpoints. For prospect mailshots the conversion that matters is not a
+     * sale but a registration, so each row also counts prospects who clicked and later became
+     * customers.
+     *
+     * Attribution shares mean a mailshot never claims the whole of a sale a paid ad also touched;
+     * summed across every channel the revenue here adds up to the shop's real revenue, not a multiple
+     * of it.
+     *
+     * @return array{totals: array{sent: int, opened: int, clicked: int, unsubscribed: int, estimated_cost: float, attributed_revenue: float, attributed_customers: float}, mailshots: array<int, array{id: int, subject: string, type: string, sent_at: string|null, sent: int, opened: int, clicked: int, unsubscribed: int, estimated_cost: float, attributed_revenue: float, attributed_customers: float, prospects_registered: int}>}
+     */
+    public function handle(Shop $shop, int $limit = 8): array
+    {
+        $usdToShop = $this->usdToShopRate($shop);
+        $costPerEmail = ((float) config('services.ses.cost_per_thousand_usd')) / 1000 * $usdToShop;
+
+        $mailshots = Mailshot::where('shop_id', $shop->id)
+            ->whereIn('type', [MailshotTypeEnum::NEWSLETTER, MailshotTypeEnum::MARKETING, MailshotTypeEnum::INVITE])
+            ->whereHas('stats', fn ($query) => $query->where('number_dispatched_emails', '>', 0))
+            ->with('stats')
+            ->orderByRaw('COALESCE(sent_at, created_at) DESC, id DESC')
+            ->limit($limit)
+            ->get();
+
+        $campaignByMailshot = TrafficSourceCampaign::query()
+            ->whereIn('reference', $mailshots->map(
+                fn (Mailshot $mailshot) => RecordEmailClickTouchpoint::CAMPAIGN_REF_PREFIX.$mailshot->id
+            ))
+            ->pluck('id', 'reference');
+
+        $campaignIds = $campaignByMailshot->values();
+
+        $customerTotals = DB::table('model_has_traffic_sources')
+            ->join('customer_stats', 'customer_stats.customer_id', '=', 'model_has_traffic_sources.model_id')
+            ->where('model_has_traffic_sources.model_type', 'Customer')
+            ->whereIn('model_has_traffic_sources.traffic_source_campaign_id', $campaignIds)
+            ->groupBy('model_has_traffic_sources.traffic_source_campaign_id')
+            ->select(
+                'model_has_traffic_sources.traffic_source_campaign_id as campaign_id',
+                DB::raw('SUM(model_has_traffic_sources.share) as customers'),
+                DB::raw('SUM(customer_stats.sales_all * model_has_traffic_sources.share) as revenue'),
+            )
+            ->get()
+            ->keyBy('campaign_id');
+
+        $prospectConversions = DB::table('model_has_traffic_sources')
+            ->join('prospects', 'prospects.id', '=', 'model_has_traffic_sources.model_id')
+            ->where('model_has_traffic_sources.model_type', 'Prospect')
+            ->whereIn('model_has_traffic_sources.traffic_source_campaign_id', $campaignIds)
+            ->whereNotNull('prospects.customer_id')
+            ->groupBy('model_has_traffic_sources.traffic_source_campaign_id')
+            ->select(
+                'model_has_traffic_sources.traffic_source_campaign_id as campaign_id',
+                DB::raw('COUNT(*) as registered'),
+            )
+            ->get()
+            ->keyBy('campaign_id');
+
+        $rows = $mailshots->map(function (Mailshot $mailshot) use ($campaignByMailshot, $customerTotals, $prospectConversions, $costPerEmail) {
+            $campaignId = $campaignByMailshot->get(RecordEmailClickTouchpoint::CAMPAIGN_REF_PREFIX.$mailshot->id);
+            $attribution = $campaignId ? $customerTotals->get($campaignId) : null;
+
+            return [
+                'id'                   => $mailshot->id,
+                'subject'              => $mailshot->subject,
+                'type'                 => $mailshot->type->value,
+                'sent_at'              => $mailshot->sent_at?->toDateString(),
+                'sent'                 => (int) $mailshot->stats->number_dispatched_emails,
+                'opened'               => (int) $mailshot->stats->number_dispatched_emails_state_opened
+                                        + (int) $mailshot->stats->number_dispatched_emails_state_clicked,
+                'clicked'              => (int) $mailshot->stats->number_dispatched_emails_state_clicked,
+                'unsubscribed'         => (int) $mailshot->stats->number_dispatched_emails_state_unsubscribed,
+                'estimated_cost'       => round($mailshot->stats->number_dispatched_emails * $costPerEmail, 2),
+                'attributed_revenue'   => round((float) ($attribution->revenue ?? 0), 2),
+                'attributed_customers' => round((float) ($attribution->customers ?? 0), 2),
+                'prospects_registered' => (int) ($campaignId ? ($prospectConversions->get($campaignId)->registered ?? 0) : 0),
+            ];
+        })->all();
+
+        return [
+            'totals'    => [
+                'sent'                 => array_sum(array_column($rows, 'sent')),
+                'opened'               => array_sum(array_column($rows, 'opened')),
+                'clicked'              => array_sum(array_column($rows, 'clicked')),
+                'unsubscribed'         => array_sum(array_column($rows, 'unsubscribed')),
+                'estimated_cost'       => round(array_sum(array_column($rows, 'estimated_cost')), 2),
+                'attributed_revenue'   => round(array_sum(array_column($rows, 'attributed_revenue')), 2),
+                'attributed_customers' => round(array_sum(array_column($rows, 'attributed_customers')), 2),
+            ],
+            'mailshots' => $rows,
+        ];
+    }
+
+    /**
+     * Falls back to 1:1 when no rate is available; for a cost this small a stale-or-missing rate must
+     * never take the dashboard down, and the figure is labelled an estimate.
+     */
+    private function usdToShopRate(Shop $shop): float
+    {
+        $usd = Currency::where('code', 'USD')->first();
+
+        if (!$usd || $usd->id === $shop->currency_id) {
+            return 1.0;
+        }
+
+        return GetCurrencyExchange::run($usd, $shop->currency) ?? 1.0;
+    }
+}

--- a/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
+++ b/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+use App\Models\Catalogue\Shop;
+use App\Models\CRM\TrafficSourceCost;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetShopMarketingOverview
+{
+    use AsAction;
+
+    /**
+     * Assembles the numbers the marketing dashboard leads with: total attributed revenue, total ad
+     * spend, the ROAS and CAC they imply, and the per-channel spend/revenue comparison. Everything is
+     * read from the traffic_source_stats rollups the hydrators maintain, so this is a handful of rows,
+     * never an aggregate over customers or orders.
+     *
+     * All figures are in the shop's currency: total_customer_revenue is summed from
+     * customer_stats.sales_all (shop currency) and total_cost is converted to shop currency on import.
+     *
+     * @return array{currency_code: string, totals: array{spend: float, revenue: float, registrations: int, purchases: int, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: int, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
+     */
+    public function handle(Shop $shop): array
+    {
+        $rows = DB::table('traffic_sources')
+            ->leftJoin('traffic_source_stats', 'traffic_source_stats.traffic_source_id', '=', 'traffic_sources.id')
+            ->where('traffic_sources.shop_id', $shop->id)
+            ->select(
+                'traffic_sources.name',
+                'traffic_sources.type',
+                DB::raw('COALESCE(traffic_source_stats.number_customers, 0) as registrations'),
+                DB::raw('COALESCE(traffic_source_stats.number_customer_purchases, 0) as purchases'),
+                DB::raw('COALESCE(traffic_source_stats.total_customer_revenue, 0) as revenue'),
+                DB::raw('COALESCE(traffic_source_stats.total_cost, 0) as spend'),
+            )
+            ->get();
+
+        $spend         = round($rows->sum('spend'), 2);
+        $revenue       = round($rows->sum('revenue'), 2);
+        $registrations = (int) $rows->sum('registrations');
+
+        $channels = $rows
+            ->filter(fn ($row) => $row->spend > 0 || $row->revenue > 0 || $row->registrations > 0)
+            ->sortByDesc(fn ($row) => max((float) $row->spend, (float) $row->revenue))
+            ->values()
+            ->map(fn ($row) => [
+                'name'          => $row->name,
+                'type'          => $row->type,
+                'spend'         => round((float) $row->spend, 2),
+                'revenue'       => round((float) $row->revenue, 2),
+                'registrations' => (int) $row->registrations,
+                'roas'          => $row->spend > 0 ? round($row->revenue / $row->spend, 2) : null,
+            ])
+            ->all();
+
+        $spendByDay = TrafficSourceCost::where('shop_id', $shop->id)
+            ->where('date', '>=', now()->subDays(30)->startOfDay())
+            ->groupBy('date')
+            ->orderBy('date')
+            ->select('date', DB::raw('SUM(amount) as amount'))
+            ->get()
+            ->map(fn ($row) => [
+                'date'   => $row->date->toDateString(),
+                'amount' => round((float) $row->amount, 2),
+            ])
+            ->all();
+
+        return [
+            'currency_code' => $shop->currency->code,
+            'totals'        => [
+                'spend'         => $spend,
+                'revenue'       => $revenue,
+                'registrations' => $registrations,
+                'purchases'     => (int) $rows->sum('purchases'),
+                'roas'          => $spend > 0 ? round($revenue / $spend, 2) : null,
+                'cac'           => ($spend > 0 && $registrations > 0) ? round($spend / $registrations, 2) : null,
+            ],
+            'channels'      => $channels,
+            'spend_by_day'  => $spendByDay,
+        ];
+    }
+}

--- a/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
+++ b/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
@@ -26,7 +26,7 @@ class GetShopMarketingOverview
      * All figures are in the shop's currency: total_customer_revenue is summed from
      * customer_stats.sales_all (shop currency) and total_cost is converted to shop currency on import.
      *
-     * @return array{currency_code: string, totals: array{spend: float, revenue: float, registrations: int, purchases: int, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: int, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
+     * @return array{currency_code: string, totals: array{spend: float, revenue: float, registrations: float, purchases: float, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: float, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
      */
     public function handle(Shop $shop): array
     {
@@ -45,7 +45,10 @@ class GetShopMarketingOverview
 
         $spend         = round($rows->sum('spend'), 2);
         $revenue       = round($rows->sum('revenue'), 2);
-        $registrations = (int) $rows->sum('registrations');
+
+        /* Share-weighted, so kept fractional: truncating per-channel figures to integers would break
+           the guarantee that channels sum to the shop's real totals. */
+        $registrations = round($rows->sum('registrations'), 2);
 
         $channels = $rows
             ->filter(fn ($row) => $row->spend > 0 || $row->revenue > 0 || $row->registrations > 0)
@@ -56,7 +59,7 @@ class GetShopMarketingOverview
                 'type'          => $row->type,
                 'spend'         => round((float) $row->spend, 2),
                 'revenue'       => round((float) $row->revenue, 2),
-                'registrations' => (int) $row->registrations,
+                'registrations' => round((float) $row->registrations, 2),
                 'roas'          => $row->spend > 0 ? round($row->revenue / $row->spend, 2) : null,
             ])
             ->all();
@@ -79,7 +82,7 @@ class GetShopMarketingOverview
                 'spend'         => $spend,
                 'revenue'       => $revenue,
                 'registrations' => $registrations,
-                'purchases'     => (int) $rows->sum('purchases'),
+                'purchases'     => round($rows->sum('purchases'), 2),
                 'roas'          => $spend > 0 ? round($revenue / $spend, 2) : null,
                 'cac'           => ($spend > 0 && $registrations > 0) ? round($spend / $registrations, 2) : null,
             ],

--- a/app/Actions/CRM/TrafficSource/GetTrafficSourceFromUrl.php
+++ b/app/Actions/CRM/TrafficSource/GetTrafficSourceFromUrl.php
@@ -25,23 +25,26 @@ class GetTrafficSourceFromUrl
             parse_str($urlComponents['query'], $queryParams);
         }
 
-        if (array_key_exists('gad_source', $queryParams) && array_key_exists('gad_campaignid', $queryParams) && array_key_exists('gclid', $queryParams)) {
+        /* gclid alone is enough to prove a paid Google click: custom tracking templates and some
+           placement types omit the gad_* parameters, and demanding all three sent that paid traffic
+           into organic via the referer fallback. The campaign id rides along when present. */
+        if (array_key_exists('gclid', $queryParams)) {
             return
                 TrafficSourcesTypeEnum::abbr()[TrafficSourcesTypeEnum::GOOGLE_ADS->value].
-                Arr::get($queryParams, 'gad_campaignid');
-
+                $this->sanitizeCampaignRef(Arr::get($queryParams, 'gad_campaignid'));
         }
 
         if (array_key_exists('fbclid', $queryParams) && array_key_exists('utm_medium', $queryParams) && $queryParams['utm_medium'] == 'paid') {
             return
                 TrafficSourcesTypeEnum::abbr()[TrafficSourcesTypeEnum::META_ADS->value].
-                Arr::get($queryParams, 'utm_campaign');
+                $this->sanitizeCampaignRef(Arr::get($queryParams, 'utm_campaign'));
         }
 
+        /* No campaign reference for Bing: msclkid is unique per click, so recording it as a campaign
+           made every Bing click a distinct campaign, over-weighting Bing in the share split and
+           matching no imported cost row ever. */
         if (array_key_exists('msclkid', $queryParams)) {
-            return
-                TrafficSourcesTypeEnum::abbr()[TrafficSourcesTypeEnum::BING_ADS->value].
-                Arr::get($queryParams, 'msclkid');
+            return TrafficSourcesTypeEnum::abbr()[TrafficSourcesTypeEnum::BING_ADS->value];
         }
 
 
@@ -50,4 +53,12 @@ class GetTrafficSourceFromUrl
         return null;
     }
 
+    /**
+     * The cookie is a pipe/comma-joined touch string, so a campaign name containing either separator
+     * would shatter the whole history into garbage segments when parsed back.
+     */
+    private function sanitizeCampaignRef(?string $reference): string
+    {
+        return preg_replace('/[|,\s]+/', '-', trim((string) $reference)) ?? '';
+    }
 }

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCosts.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCosts.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource\Hydrator;
+
+use App\Models\CRM\TrafficSource;
+use App\Models\CRM\TrafficSourceCost;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class TrafficSourceHydrateCosts implements ShouldBeUnique
+{
+    use AsAction;
+
+    public int $jobUniqueFor = 3600;
+
+    public function getJobUniqueId(TrafficSource $trafficSource): string
+    {
+        return (string) $trafficSource->id;
+    }
+
+    /**
+     * Rolls every recorded daily cost for a traffic source up into its stats row, so the listing can
+     * sort and total on spend without aggregating the cost table on every page load.
+     */
+    public function handle(TrafficSource $trafficSource): void
+    {
+        $totals = TrafficSourceCost::where('traffic_source_id', $trafficSource->id)
+            ->select(
+                DB::raw('COALESCE(SUM(amount), 0) as total_cost'),
+                DB::raw('COALESCE(SUM(org_amount), 0) as org_total_cost')
+            )
+            ->first();
+
+        $trafficSource->stats()->updateOrCreate(
+            ['traffic_source_id' => $trafficSource->id],
+            [
+                'total_cost'     => $totals->total_cost,
+                'org_total_cost' => $totals->org_total_cost,
+            ]
+        );
+    }
+}

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
@@ -19,6 +19,10 @@ class TrafficSourceHydrateCustomers implements ShouldBeUnique
 {
     use AsAction;
 
+    /* Fired from every registration, order cancel and email-click recalculation; the numbers it
+       refreshes are dashboard statistics, so it must never compete with order processing. */
+    public string $jobQueue = 'low-priority';
+
     public function getJobUniqueId(TrafficSource $trafficSource): string
     {
         return $trafficSource->id;

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
@@ -41,10 +41,16 @@ class TrafficSourceHydrateCustomers implements ShouldBeUnique
             ->select(DB::raw('SUM(number_orders_state_dispatched) as total'))
             ->first()->total ?? 0;
 
-        $stats['total_customer_revenue'] = DB::table('customer_stats')
+        $revenue = DB::table('customer_stats')
             ->whereIn('customer_id', $customerIds)
-            ->select(DB::raw('SUM(sales_all) as total'))
-            ->first()->total ?? 0;
+            ->select(
+                DB::raw('SUM(sales_all) as total'),
+                DB::raw('SUM(sales_org_currency_all) as org_total')
+            )
+            ->first();
+
+        $stats['total_customer_revenue']     = $revenue->total ?? 0;
+        $stats['org_total_customer_revenue'] = $revenue->org_total ?? 0;
 
         $trafficSource->stats()->updateOrCreate(
             ['traffic_source_id' => $trafficSource->id],

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
@@ -10,7 +10,6 @@
 
 namespace App\Actions\CRM\TrafficSource\Hydrator;
 
-use App\Actions\Traits\WithEnumStats;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -19,42 +18,40 @@ use App\Models\CRM\TrafficSource;
 class TrafficSourceHydrateCustomers implements ShouldBeUnique
 {
     use AsAction;
-    use WithEnumStats;
 
     public function getJobUniqueId(TrafficSource $trafficSource): string
     {
         return $trafficSource->id;
     }
 
+    /**
+     * Everything is weighted by the attribution share, so a customer split between channels is split
+     * here too: half a customer, half their orders, half their revenue to each. Summing any of these
+     * figures across every traffic source of a shop therefore reproduces the shop's real totals —
+     * channels share the credit, they never each claim the whole of it.
+     */
     public function handle(TrafficSource $trafficSource): void
     {
-        $customers = $trafficSource->customers;
-
-        $stats = [
-            'number_customers' => $customers->unique('id')->count(),
-        ];
-
-        $customerIds = $customers->pluck('id')->unique();
-
-        $stats['number_customer_purchases'] =  DB::table('customer_stats')
-            ->whereIn('customer_id', $customerIds)
-            ->select(DB::raw('SUM(number_orders_state_dispatched) as total'))
-            ->first()->total ?? 0;
-
-        $revenue = DB::table('customer_stats')
-            ->whereIn('customer_id', $customerIds)
+        $totals = DB::table('model_has_traffic_sources')
+            ->join('customer_stats', 'customer_stats.customer_id', '=', 'model_has_traffic_sources.model_id')
+            ->where('model_has_traffic_sources.traffic_source_id', $trafficSource->id)
+            ->where('model_has_traffic_sources.model_type', 'Customer')
             ->select(
-                DB::raw('SUM(sales_all) as total'),
-                DB::raw('SUM(sales_org_currency_all) as org_total')
+                DB::raw('COALESCE(SUM(model_has_traffic_sources.share), 0) as customers'),
+                DB::raw('COALESCE(SUM(customer_stats.number_orders_state_dispatched * model_has_traffic_sources.share), 0) as purchases'),
+                DB::raw('COALESCE(SUM(customer_stats.sales_all * model_has_traffic_sources.share), 0) as revenue'),
+                DB::raw('COALESCE(SUM(customer_stats.sales_org_currency_all * model_has_traffic_sources.share), 0) as org_revenue'),
             )
             ->first();
 
-        $stats['total_customer_revenue']     = $revenue->total ?? 0;
-        $stats['org_total_customer_revenue'] = $revenue->org_total ?? 0;
-
         $trafficSource->stats()->updateOrCreate(
             ['traffic_source_id' => $trafficSource->id],
-            $stats
+            [
+                'number_customers'           => $totals->customers,
+                'number_customer_purchases'  => $totals->purchases,
+                'total_customer_revenue'     => $totals->revenue,
+                'org_total_customer_revenue' => $totals->org_revenue,
+            ]
         );
     }
 }

--- a/app/Actions/CRM/TrafficSource/MergeTrafficSourceTouchHistories.php
+++ b/app/Actions/CRM/TrafficSource/MergeTrafficSourceTouchHistories.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class MergeTrafficSourceTouchHistories
+{
+    use AsAction;
+
+    /**
+     * Combines two raw touch histories into one, ordered by timestamp with exact duplicates dropped,
+     * so a prospect's server-side touches (mailshot clicks) and the browser-cookie touches captured at
+     * registration end up as a single journey. Touches an aggressive parse would reject are preserved
+     * verbatim rather than silently lost.
+     */
+    public function handle(?string $first, ?string $second): ?string
+    {
+        $segments = collect(preg_split('/[|,]/', ($first ?? '').'|'.($second ?? '')) ?: [])
+            ->map(fn (string $segment) => trim($segment))
+            ->filter()
+            ->unique()
+            ->sortBy(fn (string $segment) => (int) $segment)
+            ->values();
+
+        return $segments->isEmpty() ? null : $segments->implode('|');
+    }
+}

--- a/app/Actions/CRM/TrafficSource/MergeTrafficSourceTouchHistories.php
+++ b/app/Actions/CRM/TrafficSource/MergeTrafficSourceTouchHistories.php
@@ -29,6 +29,15 @@ class MergeTrafficSourceTouchHistories
             ->sortBy(fn (string $segment) => (int) $segment)
             ->values();
 
+        /* Same budget as a recorded click: keep the first touch (first-touch attribution survives)
+           and the most recent of the rest. Device cookies are client-controlled, so without this a
+           crafted cookie could grow the stored history without bound. */
+        if ($segments->count() > RecordEmailClickTouchpoint::MAX_TOUCHES) {
+            $segments = $segments->take(1)->concat(
+                $segments->slice(1)->take(-(RecordEmailClickTouchpoint::MAX_TOUCHES - 1))
+            )->values();
+        }
+
         return $segments->isEmpty() ? null : $segments->implode('|');
     }
 }

--- a/app/Actions/CRM/TrafficSource/RecordEmailClickTouchpoint.php
+++ b/app/Actions/CRM/TrafficSource/RecordEmailClickTouchpoint.php
@@ -24,6 +24,10 @@ class RecordEmailClickTouchpoint implements ShouldBeUnique
 
     public int $jobUniqueFor = 600;
 
+    /* Mailshot click bursts belong with the rest of the SES event work, not on the default queue
+       where they would compete with order processing. */
+    public string $jobQueue = 'ses-analytics';
+
     /**
      * Newsletter campaign references are namespaced because `traffic_source_campaigns.reference` is
      * unique across the whole table, not per traffic source: a bare mailshot id would collide with a

--- a/app/Actions/CRM/TrafficSource/RecordEmailClickTouchpoint.php
+++ b/app/Actions/CRM/TrafficSource/RecordEmailClickTouchpoint.php
@@ -16,6 +16,7 @@ use App\Models\CRM\TrafficSource;
 use App\Models\CRM\TrafficSourceCampaign;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class RecordEmailClickTouchpoint implements ShouldBeUnique
@@ -97,9 +98,15 @@ class RecordEmailClickTouchpoint implements ShouldBeUnique
         $abbr     = TrafficSourcesTypeEnum::NEWSLETTER->abbr()[TrafficSourcesTypeEnum::NEWSLETTER->value];
         $newTouch = $occurredAt->getTimestamp() . $abbr . ($campaignRef ?? '');
 
-        $recipient->update([
-            'traffic_sources' => $this->appendTouch($recipient->traffic_sources, $newTouch),
-        ]);
+        /* Appended under a row lock: the device-cookie sync merges into the same column from
+           another queue, and appending onto a stale read would let its write erase this click. */
+        DB::transaction(function () use ($recipient, $newTouch) {
+            $locked = $recipient->newQuery()->lockForUpdate()->find($recipient->getKey());
+
+            $locked?->update([
+                'traffic_sources' => $this->appendTouch($locked->traffic_sources, $newTouch),
+            ]);
+        });
 
         RecalculateTrafficSourceAttribution::run($recipient->fresh());
     }

--- a/app/Actions/CRM/TrafficSource/StoreTrafficSourceCost.php
+++ b/app/Actions/CRM/TrafficSource/StoreTrafficSourceCost.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCosts;
+use App\Actions\Helpers\CurrencyExchange\GetCurrencyExchange;
+use App\Actions\Helpers\CurrencyExchange\GetHistoricCurrencyExchange;
+use App\Models\CRM\TrafficSource;
+use App\Models\CRM\TrafficSourceCost;
+use App\Models\Helpers\Currency;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class StoreTrafficSourceCost
+{
+    use AsAction;
+
+    /**
+     * Records what was spent on a traffic source, optionally on one of its campaigns, for a single day.
+     *
+     * Re-importing the same day is an update rather than an insert: advertisers routinely re-export a
+     * report once a platform has finished attributing late conversions, and the second export is the
+     * more accurate one. Keyed on source + campaign + date, so a campaign-level row and the
+     * campaign-less total for the same source and day stay separate rows.
+     *
+     * @param array{date: Carbon|string, source_amount: float|string, source_currency_id: int, traffic_source_campaign_id?: int|null} $modelData
+     */
+    public function handle(TrafficSource $trafficSource, array $modelData): TrafficSourceCost
+    {
+        $date           = Carbon::parse(Arr::get($modelData, 'date'))->startOfDay();
+        $sourceAmount   = (float) Arr::get($modelData, 'source_amount');
+        $sourceCurrency = Currency::find(Arr::get($modelData, 'source_currency_id'));
+
+        $shopCurrency = $trafficSource->shop->currency;
+        $orgCurrency  = $trafficSource->organisation->currency;
+
+        $trafficSourceCost = TrafficSourceCost::updateOrCreate(
+            [
+                'traffic_source_id'          => $trafficSource->id,
+                'traffic_source_campaign_id' => Arr::get($modelData, 'traffic_source_campaign_id'),
+                'date'                       => $date,
+            ],
+            [
+                'group_id'           => $trafficSource->group_id,
+                'organisation_id'    => $trafficSource->organisation_id,
+                'shop_id'            => $trafficSource->shop_id,
+                'source_amount'      => $sourceAmount,
+                'source_currency_id' => $sourceCurrency->id,
+                'amount'             => $sourceAmount * $this->rate($sourceCurrency, $shopCurrency, $date),
+                'org_amount'         => $sourceAmount * $this->rate($sourceCurrency, $orgCurrency, $date),
+            ]
+        );
+
+        TrafficSourceHydrateCosts::dispatch($trafficSource);
+
+        return $trafficSourceCost;
+    }
+
+    /**
+     * Ad spend is converted at the rate of the day it was spent, not today's: a report imported months
+     * later would otherwise restate historic spend every time the exchange rate moved, and the ROAS of
+     * a closed period would never sit still. Falls back to the current rate when no historic rate has
+     * been fetched for that day.
+     */
+    private function rate(Currency $from, Currency $to, Carbon $date): float
+    {
+        if ($from->id === $to->id) {
+            return 1.0;
+        }
+
+        return GetHistoricCurrencyExchange::run($from, $to, $date)
+            ?? GetCurrencyExchange::run($from, $to);
+    }
+}

--- a/app/Actions/CRM/TrafficSource/SyncCustomerTrafficSourcesFromDevice.php
+++ b/app/Actions/CRM/TrafficSource/SyncCustomerTrafficSourcesFromDevice.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+use App\Models\CRM\Customer;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class SyncCustomerTrafficSourcesFromDevice implements ShouldBeUnique
+{
+    use AsAction;
+
+    /* Collapses the page-view burst of a browsing session into one job per customer. */
+    public int $jobUniqueFor = 600;
+
+    public string $jobQueue = 'low-priority';
+
+    public function getJobUniqueId(Customer $customer): string
+    {
+        return (string) $customer->id;
+    }
+
+    /**
+     * Folds the touch history a device's cookie accumulated into the customer's server-side history.
+     * The cookie is per browser, the customer is not: the ad clicked on a phone and the search made
+     * on a desktop belong to one journey, and the customer row is the only place both can meet.
+     * Touches already known are deduplicated by the merge, so replaying the same cookie is a no-op.
+     */
+    public function handle(Customer $customer, string $deviceTouches): void
+    {
+        $merged = MergeTrafficSourceTouchHistories::run($customer->traffic_sources, $deviceTouches);
+
+        if ($merged === $customer->traffic_sources) {
+            return;
+        }
+
+        $customer->update(['traffic_sources' => $merged]);
+
+        RecalculateTrafficSourceAttribution::run($customer->fresh());
+    }
+}

--- a/app/Actions/CRM/TrafficSource/SyncCustomerTrafficSourcesFromDevice.php
+++ b/app/Actions/CRM/TrafficSource/SyncCustomerTrafficSourcesFromDevice.php
@@ -10,6 +10,7 @@ namespace App\Actions\CRM\TrafficSource;
 
 use App\Models\CRM\Customer;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class SyncCustomerTrafficSourcesFromDevice implements ShouldBeUnique
@@ -34,14 +35,55 @@ class SyncCustomerTrafficSourcesFromDevice implements ShouldBeUnique
      */
     public function handle(Customer $customer, string $deviceTouches): void
     {
-        $merged = MergeTrafficSourceTouchHistories::run($customer->traffic_sources, $deviceTouches);
+        $deviceTouches = self::sanitize($deviceTouches);
 
-        if ($merged === $customer->traffic_sources) {
+        if (blank($deviceTouches)) {
             return;
         }
 
-        $customer->update(['traffic_sources' => $merged]);
+        /* Read-merge-write under a row lock: RecordEmailClickTouchpoint appends to the same column
+           from another queue, and merging against a stale read would silently erase its click. */
+        $changed = DB::transaction(function () use ($customer, $deviceTouches): bool {
+            $locked = Customer::lockForUpdate()->find($customer->id);
 
-        RecalculateTrafficSourceAttribution::run($customer->fresh());
+            if (!$locked) {
+                return false;
+            }
+
+            $merged = MergeTrafficSourceTouchHistories::run($locked->traffic_sources, $deviceTouches);
+
+            if ($merged === $locked->traffic_sources) {
+                return false;
+            }
+
+            $locked->update(['traffic_sources' => $merged]);
+
+            return true;
+        });
+
+        if ($changed) {
+            RecalculateTrafficSourceAttribution::run($customer->fresh());
+        }
+    }
+
+    /**
+     * The cookie is raw client data and this job writes it into server-side attribution state, so
+     * only touches that would survive parsing get through, and only with credible timestamps: a
+     * forged epoch-zero segment would otherwise claim the permanent first-touch slot, and garbage
+     * would sit in the customer's history forever. The touch string is rebuilt from the parsed form,
+     * never passed through verbatim.
+     */
+    public static function sanitize(?string $deviceTouches): ?string
+    {
+        $floor   = 1577836800; // 2020-01-01, comfortably before any touch this system could have made
+        $ceiling = now()->addDay()->timestamp;
+
+        $segments = collect(ParseTrafficSourceTouches::run($deviceTouches))
+            ->filter(fn (array $touch) => $touch['timestamp'] !== null
+                && $touch['timestamp'] >= $floor
+                && $touch['timestamp'] <= $ceiling)
+            ->map(fn (array $touch) => $touch['timestamp'].$touch['abbr'].($touch['campaign_ref'] ?? ''));
+
+        return $segments->isEmpty() ? null : $segments->implode('|');
     }
 }

--- a/app/Actions/CRM/TrafficSource/UI/IndexTrafficSources.php
+++ b/app/Actions/CRM/TrafficSource/UI/IndexTrafficSources.php
@@ -14,6 +14,7 @@ use App\Models\SysAdmin\Organisation;
 use App\Services\QueryBuilder;
 use Closure;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 use Lorisleiva\Actions\ActionRequest;
@@ -57,14 +58,32 @@ class IndexTrafficSources extends OrgAction
         });
 
 
+        /* Both figures have to be in the currency this screen labels them with: the organisation-scoped
+           listing joins the organisation's currency, the shop-scoped one the shop's. Picking the wrong
+           pair would not just mislabel them, it would make the return on ad spend below a ratio between
+           two different currencies. */
+        $costField    = $parent instanceof Organisation ? 'org_total_cost' : 'total_cost';
+        $revenueField = $parent instanceof Organisation ? 'org_total_customer_revenue' : 'total_customer_revenue';
+
         $selectFields = [
             'traffic_sources.id',
             'traffic_sources.slug',
             'traffic_sources.name',
             'traffic_source_stats.number_customers',
             'traffic_source_stats.number_customer_purchases',
-            'traffic_source_stats.total_customer_revenue',
+            "traffic_source_stats.{$revenueField} as total_customer_revenue",
+            "traffic_source_stats.{$costField} as cost",
             'currencies.code as currency_code',
+
+            /* Guarded against the no-spend case, which is every source until costs are imported and
+               permanently the case for organic ones: a null reads as "not applicable" in the table,
+               where a zero would read as "this campaign returned nothing". */
+            DB::raw("CASE WHEN traffic_source_stats.{$costField} > 0
+                        THEN ROUND(traffic_source_stats.{$revenueField} / traffic_source_stats.{$costField}, 2)
+                    END as roas"),
+            DB::raw("CASE WHEN traffic_source_stats.number_customers > 0 AND traffic_source_stats.{$costField} > 0
+                        THEN ROUND(traffic_source_stats.{$costField} / traffic_source_stats.number_customers, 2)
+                    END as cac"),
         ];
 
         $groupByFields = [
@@ -83,6 +102,9 @@ class IndexTrafficSources extends OrgAction
             'number_customers',
             'number_customer_purchases',
             'total_customer_revenue',
+            'cost',
+            'roas',
+            'cac',
         ];
 
         return $queryBuilder
@@ -110,8 +132,10 @@ class IndexTrafficSources extends OrgAction
                 ->column(key: 'name', label: __('Name'), canBeHidden: false, sortable: true, searchable: true)
                 ->column(key: 'number_customers', label: __('Registrations'), canBeHidden: false, sortable: true, searchable: true)
                 ->column(key: 'number_customer_purchases', label: __('Orders'), canBeHidden: false, sortable: true)
-                ->column(key: 'cost', label: __('Cost'), canBeHidden: false)
-                ->column(key: 'total_customer_revenue', label: __('Revenue'), canBeHidden: false, sortable: true, type: 'currency');
+                ->column(key: 'cost', label: __('Cost'), canBeHidden: false, sortable: true, type: 'currency')
+                ->column(key: 'total_customer_revenue', label: __('Revenue'), canBeHidden: false, sortable: true, type: 'currency')
+                ->column(key: 'roas', label: __('ROAS'), canBeHidden: true, sortable: true)
+                ->column(key: 'cac', label: __('CAC'), canBeHidden: true, sortable: true, type: 'currency');
         };
     }
 

--- a/app/Actions/CRM/TrafficSource/UI/ShowTrafficSource.php
+++ b/app/Actions/CRM/TrafficSource/UI/ShowTrafficSource.php
@@ -97,16 +97,16 @@ class ShowTrafficSource extends OrgAction
         $trafficSource = TrafficSource::where('slug', $routeParameters['trafficSource'])->first();
 
         return match ($routeName) {
-            'grp.org.shops.show.crm.traffic_sources.show' =>
+            'grp.org.shops.show.marketing.traffic_sources.show' =>
             array_merge(
-                IndexTrafficSources::make()->getBreadcrumbs('grp.org.shops.show.crm.traffic_sources.show', [
+                IndexTrafficSources::make()->getBreadcrumbs([
                     'organisation' => $trafficSource->organisation->slug,
                     'shop'         => $trafficSource->shop->slug,
                 ]),
                 $headCrumb(
                     $trafficSource,
                     [
-                        'name'       => 'grp.org.shops.show.crm.traffic_sources.show',
+                        'name'       => 'grp.org.shops.show.marketing.traffic_sources.show',
                         'parameters' => $routeParameters
                     ],
                     $suffix

--- a/app/Actions/CRM/WebUser/Retina/RetinaLogout.php
+++ b/app/Actions/CRM/WebUser/Retina/RetinaLogout.php
@@ -30,6 +30,11 @@ class RetinaLogout
 
         Cookie::queue(Cookie::forget('iris_vua'));
 
+        /* The touch history belongs to the journey that just ended. On a shared browser the next
+           person to log in must not inherit it into their own attribution record. */
+        Cookie::queue(Cookie::forget('aiku_tsd'));
+        Cookie::queue(Cookie::forget('aiku_lts'));
+
         return Redirect::back();
 
     }

--- a/app/Actions/Comms/EmailTrackingEvent/StoreEmailTrackingEvent.php
+++ b/app/Actions/Comms/EmailTrackingEvent/StoreEmailTrackingEvent.php
@@ -32,14 +32,20 @@ class StoreEmailTrackingEvent extends OrgAction
         if ($emailTrackingEvent->type == EmailTrackingEventTypeEnum::CLICKED) {
             DispatchedEmailHydrateClicks::run($dispatchedEmail);
 
-            $clickedAt = $emailTrackingEvent->created_at ?? now();
+            /* Only mailshot clicks are marketing touches. Transactional sends (order confirmations,
+               dispatch notices, invoices) reach the same CLICKED state, and recording those would
+               hand the newsletter channel a share of every engaged customer's revenue for clicks
+               that are post-purchase service, not acquisition. */
+            if ($dispatchedEmail->mailshot) {
+                $clickedAt = $emailTrackingEvent->created_at ?? now();
 
-            foreach ($dispatchedEmail->customers as $customer) {
-                RecordEmailClickTouchpoint::dispatch($customer, $clickedAt, $dispatchedEmail->mailshot);
-            }
+                foreach ($dispatchedEmail->customers as $customer) {
+                    RecordEmailClickTouchpoint::dispatch($customer, $clickedAt, $dispatchedEmail->mailshot);
+                }
 
-            foreach ($dispatchedEmail->prospects as $prospect) {
-                RecordEmailClickTouchpoint::dispatch($prospect, $clickedAt, $dispatchedEmail->mailshot);
+                foreach ($dispatchedEmail->prospects as $prospect) {
+                    RecordEmailClickTouchpoint::dispatch($prospect, $clickedAt, $dispatchedEmail->mailshot);
+                }
             }
         } elseif ($emailTrackingEvent->type == EmailTrackingEventTypeEnum::OPENED) {
             DispatchedEmailHydrateReads::run($dispatchedEmail);

--- a/app/Actions/Helpers/CurrencyExchange/Providers/FetchCurrencyExchangeCurrencyBeacon.php
+++ b/app/Actions/Helpers/CurrencyExchange/Providers/FetchCurrencyExchangeCurrencyBeacon.php
@@ -56,7 +56,7 @@ class FetchCurrencyExchangeCurrencyBeacon
         }
 
 
-        $response = Http::get($url, $parameters);
+        $response = Http::timeout(3)->get($url, $parameters);
         if ($response->status() != 200) {
             return [
                 'status'   => 'error',

--- a/app/Actions/Helpers/CurrencyExchange/Providers/FetchCurrencyExchangeFrankfurter.php
+++ b/app/Actions/Helpers/CurrencyExchange/Providers/FetchCurrencyExchangeFrankfurter.php
@@ -36,7 +36,7 @@ class FetchCurrencyExchangeFrankfurter
         }
 
 
-        $response = Http::get($url, [
+        $response = Http::timeout(3)->get($url, [
             'from' => $baseCurrency->code,
             'to'   => $targetCurrency->code
         ]);

--- a/app/Actions/Iris/CaptureTrafficSource.php
+++ b/app/Actions/Iris/CaptureTrafficSource.php
@@ -115,7 +115,7 @@ class CaptureTrafficSource
         $website = request()->input('website');
 
 
-        if (auth()->check() && $website->type == WebsiteTypeEnum::DROPSHIPPING) {
+        if (auth()->check() && $website?->type == WebsiteTypeEnum::DROPSHIPPING) {
             return false;
         }
 
@@ -123,9 +123,14 @@ class CaptureTrafficSource
         return true;
     }
 
+    /**
+     * The cookie is pipe-joined; splitting on the wrong separator here used to return the whole
+     * history as one segment and slice it to nothing, wiping the visitor's touches the moment the
+     * cookie hit its size cap.
+     */
     public function trimOldestTrafficSource($trafficSourceData): string
     {
-        $trafficSourceData = explode(',', $trafficSourceData);
+        $trafficSourceData = preg_split('/[|,]/', $trafficSourceData) ?: [];
         $trafficSourceData = array_slice($trafficSourceData, 1);
 
         return implode('|', $trafficSourceData);

--- a/app/Actions/Ordering/Order/ProcessOrderTrafficSource.php
+++ b/app/Actions/Ordering/Order/ProcessOrderTrafficSource.php
@@ -10,6 +10,7 @@ namespace App\Actions\Ordering\Order;
 
 use App\Actions\CRM\TrafficSource\AttachTrafficSourcesToModel;
 use App\Actions\CRM\TrafficSource\ParseTrafficSourceTouches;
+use App\Actions\CRM\TrafficSource\ProcessTrafficSourceShare;
 use App\Models\Ordering\Order;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -49,6 +50,11 @@ class ProcessOrderTrafficSource implements ShouldBeUnique
             return;
         }
 
-        AttachTrafficSourcesToModel::run($order, $order->shop_id, $touches);
+        /* Attribute the order under the same model its customer is on, so order-level and
+           customer-level numbers cannot silently disagree for anyone moved off the default. */
+        $attributionModel = $order->customer?->trafficSources()->first()?->pivot->attribution_model
+            ?? ProcessTrafficSourceShare::ATTRIBUTION_LINEAR;
+
+        AttachTrafficSourcesToModel::run($order, $order->shop_id, $touches, $attributionModel);
     }
 }

--- a/app/Actions/Traits/HasIrisUserData.php
+++ b/app/Actions/Traits/HasIrisUserData.php
@@ -108,18 +108,24 @@ trait HasIrisUserData
      */
     private function syncDeviceTrafficSources(): void
     {
-        $deviceTouches = (string) request()->cookie('aiku_tsd', '');
+        /* Attribution bookkeeping on the storefront hot path: nothing here may ever break a
+           customer's page. A failed queue dispatch is a lost sync, not a lost page view. */
+        try {
+            $deviceTouches = (string) request()->cookie('aiku_tsd', '');
 
-        $customer = $this->customer ?? null;
+            $customer = $this->customer ?? null;
 
-        if (blank($deviceTouches) || !$customer instanceof \App\Models\CRM\Customer) {
-            return;
-        }
+            if (blank($deviceTouches) || !$customer instanceof \App\Models\CRM\Customer) {
+                return;
+            }
 
-        $merged = MergeTrafficSourceTouchHistories::run($customer->traffic_sources, $deviceTouches);
+            $merged = MergeTrafficSourceTouchHistories::run($customer->traffic_sources, $deviceTouches);
 
-        if ($merged !== $customer->traffic_sources) {
-            SyncCustomerTrafficSourcesFromDevice::dispatch($customer, $deviceTouches);
+            if ($merged !== $customer->traffic_sources) {
+                SyncCustomerTrafficSourcesFromDevice::dispatch($customer, $deviceTouches);
+            }
+        } catch (\Throwable $e) {
+            report($e);
         }
     }
 }

--- a/app/Actions/Traits/HasIrisUserData.php
+++ b/app/Actions/Traits/HasIrisUserData.php
@@ -8,6 +8,8 @@
 
 namespace App\Actions\Traits;
 
+use App\Actions\CRM\TrafficSource\MergeTrafficSourceTouchHistories;
+use App\Actions\CRM\TrafficSource\SyncCustomerTrafficSourcesFromDevice;
 use App\Actions\Iris\CaptureTrafficSource;
 use App\Enums\Catalogue\Shop\ShopTypeEnum;
 use App\Enums\Dropshipping\CustomerSalesChannelStatusEnum;
@@ -22,6 +24,8 @@ trait HasIrisUserData
     public function getIrisUserData(): array
     {
         $webUser = $this->webUser;
+
+        $this->syncDeviceTrafficSources();
 
         $cartCount                    = 0;
         $cartAmount                   = 0;
@@ -94,5 +98,28 @@ trait HasIrisUserData
             'offer_meters'           => $offerMeters,
             'offer_data'             => $offerData, // this is used in the top bar
         ];
+    }
+
+    /**
+     * The touch cookie is per browser, but the customer browses on several: fold this device's
+     * cookie into the customer's server-side history so the ad clicked on the phone and the search
+     * made on the desktop meet in one journey. Inline work is a string merge and comparison, only a
+     * genuinely new touch dispatches the (unique, low-priority) sync job.
+     */
+    private function syncDeviceTrafficSources(): void
+    {
+        $deviceTouches = (string) request()->cookie('aiku_tsd', '');
+
+        $customer = $this->customer ?? null;
+
+        if (blank($deviceTouches) || !$customer instanceof \App\Models\CRM\Customer) {
+            return;
+        }
+
+        $merged = MergeTrafficSourceTouchHistories::run($customer->traffic_sources, $deviceTouches);
+
+        if ($merged !== $customer->traffic_sources) {
+            SyncCustomerTrafficSourcesFromDevice::dispatch($customer, $deviceTouches);
+        }
     }
 }

--- a/app/Actions/Traits/HasIrisUserData.php
+++ b/app/Actions/Traits/HasIrisUserData.php
@@ -111,7 +111,12 @@ trait HasIrisUserData
         /* Attribution bookkeeping on the storefront hot path: nothing here may ever break a
            customer's page. A failed queue dispatch is a lost sync, not a lost page view. */
         try {
-            $deviceTouches = (string) request()->cookie('aiku_tsd', '');
+            /* Sanitized here too, with the same rules the job applies, so the dispatch decision and
+               the job's outcome agree - comparing raw cookie against sanitized state would re-queue
+               a job forever for any visitor whose cookie holds rejected segments. */
+            $deviceTouches = SyncCustomerTrafficSourcesFromDevice::sanitize(
+                (string) request()->cookie('aiku_tsd', '')
+            );
 
             $customer = $this->customer ?? null;
 

--- a/app/Actions/Traits/WithCustomersSubNavigation.php
+++ b/app/Actions/Traits/WithCustomersSubNavigation.php
@@ -54,7 +54,7 @@ trait WithCustomersSubNavigation
 
             $meta[] = [
                 'route'     => [
-                    'name'       => 'grp.org.shops.show.crm.traffic_sources.index',
+                    'name'       => 'grp.org.shops.show.marketing.traffic_sources.index',
                     'parameters' => $request->route()->originalParameters()
                 ],
                 'number'   => $this->parent->crmStats?->number_traffic_sources ?? 0,

--- a/app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php
+++ b/app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php
@@ -9,6 +9,7 @@
 namespace App\Actions\UI\Dropshipping\Marketing;
 
 use App\Actions\Catalogue\Shop\UI\ShowShop;
+use App\Actions\CRM\TrafficSource\GetShopEmailMarketingPerformance;
 use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
 use App\Actions\OrgAction;
 use App\Enums\UI\Marketing\MarketingDashboardTabsEnum;
@@ -77,8 +78,13 @@ class ShowMarketingDashboard extends OrgAction
                 'marketing_overview' => array_merge(
                     GetShopMarketingOverview::run($this->shop),
                     [
+                        'email'                 => GetShopEmailMarketingPerformance::run($this->shop),
                         'traffic_sources_route' => [
                             'name'       => 'grp.org.shops.show.marketing.traffic_sources.index',
+                            'parameters' => $request->route()->originalParameters()
+                        ],
+                        'mailshots_route'       => [
+                            'name'       => 'grp.org.shops.show.marketing.mailshots.index',
                             'parameters' => $request->route()->originalParameters()
                         ],
                     ]

--- a/app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php
+++ b/app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php
@@ -9,6 +9,7 @@
 namespace App\Actions\UI\Dropshipping\Marketing;
 
 use App\Actions\Catalogue\Shop\UI\ShowShop;
+use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
 use App\Actions\OrgAction;
 use App\Enums\UI\Marketing\MarketingDashboardTabsEnum;
 use App\Models\Catalogue\Shop;
@@ -73,6 +74,15 @@ class ShowMarketingDashboard extends OrgAction
                     'current'    => $this->tab,
                     'navigation' => MarketingDashboardTabsEnum::navigation()
                 ],
+                'marketing_overview' => array_merge(
+                    GetShopMarketingOverview::run($this->shop),
+                    [
+                        'traffic_sources_route' => [
+                            'name'       => 'grp.org.shops.show.marketing.traffic_sources.index',
+                            'parameters' => $request->route()->originalParameters()
+                        ],
+                    ]
+                ),
                 'dashboard_stats'   => [
                     [
                         'name' => __('Newsletters'),

--- a/app/Console/Commands/ImportTrafficSourceCosts.php
+++ b/app/Console/Commands/ImportTrafficSourceCosts.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Console\Commands;
+
+use App\Actions\CRM\TrafficSource\StoreTrafficSourceCost;
+use App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum;
+use App\Models\Catalogue\Shop;
+use App\Models\CRM\TrafficSource;
+use App\Models\CRM\TrafficSourceCampaign;
+use App\Models\Helpers\Currency;
+use Illuminate\Console\Command;
+
+/**
+ * Imports advertising spend from a CSV, one row per source (or campaign) per day:
+ *
+ *   shop,source,campaign,date,amount,currency
+ *   uk,google-ads,22872123321,2026-08-01,153.22,GBP
+ *   uk,meta-ads,,2026-08-01,88.40,GBP
+ *
+ * `campaign` is optional and matches `traffic_source_campaigns.reference`, which is what the touch
+ * history already stores, so a Google Ads campaign id pasted straight out of the platform lines up
+ * with the attribution data without any mapping step. A blank campaign records the source's total for
+ * the day, and both can coexist for the same day.
+ *
+ * ponytail: deliberately a command over a CSV rather than an upload-tracked import. The Upload
+ * machinery buys per-row audit records that nothing reads yet, and every existing importer that uses
+ * it is broken against StoreUpload's current signature. Wire it in when the feature grows a UI.
+ */
+class ImportTrafficSourceCosts extends Command
+{
+    protected $signature = 'traffic-source:import-costs
+                           {file : Path to the CSV file}
+                           {--dry-run : Parse and validate without writing anything}';
+
+    protected $description = 'Import advertising spend per traffic source and day from a CSV';
+
+    private const COLUMNS = ['shop', 'source', 'campaign', 'date', 'amount', 'currency'];
+
+    public function handle(): int
+    {
+        $path = $this->argument('file');
+
+        if (!is_readable($path)) {
+            $this->error("Cannot read '{$path}'.");
+
+            return Command::FAILURE;
+        }
+
+        $handle = fopen($path, 'r');
+        $header = fgetcsv($handle);
+
+        if ($header === false) {
+            $this->error('The file is empty.');
+            fclose($handle);
+
+            return Command::FAILURE;
+        }
+
+        $header  = array_map(fn ($column) => strtolower(trim((string) $column)), $header);
+        $missing = array_diff(self::COLUMNS, $header);
+
+        if ($missing) {
+            $this->error('Missing column(s): '.implode(', ', $missing).'.');
+            $this->line('Expected header: '.implode(',', self::COLUMNS));
+            fclose($handle);
+
+            return Command::FAILURE;
+        }
+
+        $imported   = 0;
+        $failed     = 0;
+        $rowNumber  = 1;
+
+        while (($values = fgetcsv($handle)) !== false) {
+            $rowNumber++;
+
+            if ($values === [null] || $values === []) {
+                continue;
+            }
+
+            $row = array_combine($header, array_pad(array_slice($values, 0, count($header)), count($header), null));
+
+            try {
+                $this->importRow($row);
+                $imported++;
+            } catch (\Throwable $e) {
+                $failed++;
+                $this->line("  <fg=red>row {$rowNumber}</>: ".$e->getMessage());
+            }
+        }
+
+        fclose($handle);
+
+        $this->newLine();
+
+        if ($this->option('dry-run')) {
+            $this->info("Dry run: {$imported} row(s) would be imported, {$failed} rejected.");
+
+            return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+        }
+
+        $this->info("Imported {$imported} row(s), rejected {$failed}.");
+
+        return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function importRow(array $row): void
+    {
+        $shop = Shop::where('slug', trim((string) $row['shop']))->first();
+
+        if (!$shop) {
+            throw new \RuntimeException("unknown shop '{$row['shop']}'");
+        }
+
+        $type = TrafficSourcesTypeEnum::tryFrom(trim((string) $row['source']));
+
+        if ($type === null) {
+            throw new \RuntimeException("unknown traffic source '{$row['source']}'");
+        }
+
+        $trafficSource = TrafficSource::where('shop_id', $shop->id)
+            ->where('type', $type->value)
+            ->first();
+
+        if (!$trafficSource) {
+            throw new \RuntimeException("shop '{$shop->slug}' has no '{$type->value}' traffic source");
+        }
+
+        $currency = Currency::where('code', strtoupper(trim((string) $row['currency'])))->first();
+
+        if (!$currency) {
+            throw new \RuntimeException("unknown currency '{$row['currency']}'");
+        }
+
+        if (!is_numeric($row['amount'])) {
+            throw new \RuntimeException("amount '{$row['amount']}' is not a number");
+        }
+
+        $campaignId = null;
+
+        if (filled($row['campaign'])) {
+            $campaignId = TrafficSourceCampaign::where('traffic_source_id', $trafficSource->id)
+                ->where('reference', trim((string) $row['campaign']))
+                ->value('id');
+
+            if (!$campaignId) {
+                throw new \RuntimeException("no campaign '{$row['campaign']}' for {$type->value} in shop '{$shop->slug}'");
+            }
+        }
+
+        if ($this->option('dry-run')) {
+            return;
+        }
+
+        StoreTrafficSourceCost::run($trafficSource, [
+            'date'                       => trim((string) $row['date']),
+            'source_amount'              => (float) $row['amount'],
+            'source_currency_id'         => $currency->id,
+            'traffic_source_campaign_id' => $campaignId,
+        ]);
+    }
+}

--- a/app/Http/Resources/CRM/TrafficSourcesResource.php
+++ b/app/Http/Resources/CRM/TrafficSourcesResource.php
@@ -31,6 +31,12 @@ class TrafficSourcesResource extends JsonResource
             'number_customers'  => $trafficSource->number_customers ?? 0,
             'number_customer_purchases' => $trafficSource->number_customer_purchases ?? 0,
             'total_customer_revenue' => $trafficSource->total_customer_revenue ?? 0,
+            'cost'              => $trafficSource->cost ?? 0,
+
+            /* Deliberately null rather than 0 when there is no spend to divide by: the table renders a
+               dash, which says "no ad spend recorded" instead of claiming a return of zero. */
+            'roas'              => $trafficSource->roas,
+            'cac'               => $trafficSource->cac,
             'created_at'        => $trafficSource->created_at,
             'updated_at'        => $trafficSource->updated_at,
         ];

--- a/app/Models/CRM/Customer.php
+++ b/app/Models/CRM/Customer.php
@@ -237,6 +237,9 @@ class Customer extends Model implements HasMedia, Auditable
     use Notifiable;
     use HasSearchableText;
     use HasSearch;
+    /* A recorded marketing touch is telemetry, not an edit someone made; auditing it would write an
+       audit row for every tracked email click. */
+    protected array $auditExclude = ['traffic_sources'];
 
     protected $casts = [
         'data'                        => 'array',

--- a/app/Models/CRM/Prospect.php
+++ b/app/Models/CRM/Prospect.php
@@ -116,6 +116,7 @@ class Prospect extends Model implements Auditable
     use HasAddresses;
     use HasHistory;
     use HasSearch;
+    protected array $auditExclude = ['traffic_sources'];
 
     protected $casts = [
         'data'                    => 'array',

--- a/app/Models/CRM/TrafficSourceCost.php
+++ b/app/Models/CRM/TrafficSourceCost.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Models\CRM;
+
+use App\Models\Helpers\Currency;
+use App\Models\Traits\InShop;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * App\Models\CRM\TrafficSourceCost
+ *
+ * @property int $id
+ * @property int $group_id
+ * @property int $organisation_id
+ * @property int $shop_id
+ * @property int $traffic_source_id
+ * @property int|null $traffic_source_campaign_id
+ * @property \Illuminate\Support\Carbon $date
+ * @property string $amount
+ * @property string $org_amount
+ * @property string $source_amount
+ * @property int $source_currency_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read TrafficSource $trafficSource
+ * @property-read TrafficSourceCampaign|null $trafficSourceCampaign
+ * @property-read Currency $sourceCurrency
+ * @mixin \Eloquent
+ */
+class TrafficSourceCost extends Model
+{
+    use HasFactory;
+    use InShop;
+
+    protected $guarded = [];
+
+    protected function casts(): array
+    {
+        return [
+            'date'          => 'date',
+            'amount'        => 'decimal:2',
+            'org_amount'    => 'decimal:2',
+            'source_amount' => 'decimal:2',
+        ];
+    }
+
+    public function trafficSource(): BelongsTo
+    {
+        return $this->belongsTo(TrafficSource::class);
+    }
+
+    public function trafficSourceCampaign(): BelongsTo
+    {
+        return $this->belongsTo(TrafficSourceCampaign::class);
+    }
+
+    public function sourceCurrency(): BelongsTo
+    {
+        return $this->belongsTo(Currency::class, 'source_currency_id');
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -31,8 +31,9 @@ return [
         'region'            => env('AWS_DEFAULT_REGION', 'eu-west-1'),
         'configuration_set' => env('AWS_CONFIGURATION_SET'),
 
-        /* SES bills per message sent, in USD. Used to estimate what a mailshot cost. */
-        'cost_per_thousand_usd' => env('SES_COST_PER_THOUSAND_USD', 0.10),
+        /* Average billed cost per thousand messages in USD, SNS event notifications included.
+           Used to estimate what a mailshot cost. */
+        'cost_per_thousand_usd' => env('SES_COST_PER_THOUSAND_USD', 0.1023),
     ],
 
     'tiktok'    => [

--- a/config/services.php
+++ b/config/services.php
@@ -30,6 +30,9 @@ return [
         'secret'            => env('AWS_SECRET_ACCESS_KEY'),
         'region'            => env('AWS_DEFAULT_REGION', 'eu-west-1'),
         'configuration_set' => env('AWS_CONFIGURATION_SET'),
+
+        /* SES bills per message sent, in USD. Used to estimate what a mailshot cost. */
+        'cost_per_thousand_usd' => env('SES_COST_PER_THOUSAND_USD', 0.10),
     ],
 
     'tiktok'    => [

--- a/database/migrations/2026_08_06_180000_create_traffic_source_costs_table.php
+++ b/database/migrations/2026_08_06_180000_create_traffic_source_costs_table.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use App\Stubs\Migrations\HasGroupOrganisationRelationship;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    use HasGroupOrganisationRelationship;
+
+    public function up(): void
+    {
+        Schema::create('traffic_source_costs', function (Blueprint $table) {
+            $table->increments('id');
+            $table = $this->groupOrgRelationship($table);
+            $table->unsignedSmallInteger('shop_id')->index();
+            $table->foreign('shop_id')->references('id')->on('shops')->nullOnDelete();
+
+            $table->unsignedInteger('traffic_source_id');
+            $table->foreign('traffic_source_id')->references('id')->on('traffic_sources')->cascadeOnDelete();
+            $table->unsignedInteger('traffic_source_campaign_id')->nullable();
+            $table->foreign('traffic_source_campaign_id')->references('id')->on('traffic_source_campaigns')->nullOnDelete();
+
+            $table->date('date');
+
+            /* `amount` is in the shop's currency so it can be compared against the revenue in
+               traffic_source_stats, which is summed from customer_stats and is therefore also in shop
+               currency. `org_amount` mirrors the convention used by payments and invoices and lets the
+               organisation-scoped listing add up shops that bill in different currencies. */
+            $table->decimal('amount', 16, 2)->default(0);
+            $table->decimal('org_amount', 16, 2)->default(0);
+
+            /* Kept so a figure can always be traced back to what the advertiser was actually billed,
+               independently of whatever exchange rate was applied on import. */
+            $table->decimal('source_amount', 16, 2)->default(0);
+            $table->unsignedSmallInteger('source_currency_id');
+            $table->foreign('source_currency_id')->references('id')->on('currencies');
+
+
+            $table->timestampsTz();
+
+            $table->index(['shop_id', 'date']);
+            $table->index(['traffic_source_id', 'date']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('traffic_source_costs');
+    }
+};

--- a/database/migrations/2026_08_06_180100_add_cost_to_traffic_source_stats_table.php
+++ b/database/migrations/2026_08_06_180100_add_cost_to_traffic_source_stats_table.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('traffic_source_stats', function (Blueprint $table) {
+            $table->decimal('total_cost', 16, 2)->default(0)->after('total_customer_revenue');
+            $table->decimal('org_total_cost', 16, 2)->default(0)->after('total_cost');
+
+            /* The organisation-scoped listing labels its figures with the organisation's currency, but
+               total_customer_revenue is summed from customer_stats.sales_all and is therefore in the
+               shop's. Carrying the organisation-currency total as well keeps cost and revenue in the
+               same unit on that screen, which is the whole point of showing a return on ad spend. */
+            $table->decimal('org_total_customer_revenue', 16, 2)->default(0)->after('total_customer_revenue');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('traffic_source_stats', function (Blueprint $table) {
+            $table->dropColumn(['total_cost', 'org_total_cost', 'org_total_customer_revenue']);
+        });
+    }
+};

--- a/database/migrations/2026_08_06_210000_make_traffic_source_stats_counts_fractional.php
+++ b/database/migrations/2026_08_06_210000_make_traffic_source_stats_counts_fractional.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Attribution splits one customer's credit across every channel that touched them, so a channel's
+     * customer count is a sum of fractional shares, not a row count: a customer acquired half by
+     * google-ads and half by a newsletter contributes 0.5 to each. Integer columns forced each channel
+     * to claim the whole customer, which made the channels sum to more than reality.
+     */
+    public function up(): void
+    {
+        Schema::table('traffic_source_stats', function (Blueprint $table) {
+            $table->decimal('number_customers', 12, 2)->default(0)->change();
+            $table->decimal('number_customer_purchases', 12, 2)->default(0)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('traffic_source_stats', function (Blueprint $table) {
+            $table->unsignedInteger('number_customers')->default(0)->change();
+            $table->unsignedInteger('number_customer_purchases')->default(0)->change();
+        });
+    }
+};

--- a/database/migrations/2026_08_06_230000_create_marketing_performance_views.php
+++ b/database/migrations/2026_08_06_230000_create_marketing_performance_views.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * Read-only views for ad-hoc and AI-assisted SQL over marketing performance. The underlying
+     * pivot is polymorphic and share-weighted, and mailshot attribution hangs off a campaign
+     * reference convention; both are easy to query wrongly (full-revenue joins double-count across
+     * channels). These views bake the correct semantics in once, so a plain SELECT gives honest
+     * numbers.
+     */
+    public function up(): void
+    {
+        DB::statement("
+            CREATE OR REPLACE VIEW marketing_channel_performance AS
+            SELECT
+                ts.id                                            AS traffic_source_id,
+                ts.shop_id,
+                s.slug                                           AS shop,
+                ts.name                                          AS channel,
+                ts.type,
+                COALESCE(st.number_customers, 0)                 AS registrations,
+                COALESCE(st.number_customer_purchases, 0)        AS orders,
+                COALESCE(st.total_customer_revenue, 0)           AS revenue,
+                COALESCE(st.total_cost, 0)                       AS cost,
+                CASE WHEN COALESCE(st.total_cost, 0) > 0
+                    THEN ROUND(st.total_customer_revenue / st.total_cost, 2)
+                END                                              AS roas,
+                CASE WHEN COALESCE(st.total_cost, 0) > 0 AND COALESCE(st.number_customers, 0) > 0
+                    THEN ROUND(st.total_cost / st.number_customers, 2)
+                END                                              AS cost_per_registration
+            FROM traffic_sources ts
+            JOIN shops s ON s.id = ts.shop_id
+            LEFT JOIN traffic_source_stats st ON st.traffic_source_id = ts.id
+        ");
+
+        DB::statement("
+            CREATE OR REPLACE VIEW marketing_mailshot_performance AS
+            SELECT
+                m.id                                                          AS mailshot_id,
+                m.shop_id,
+                s.slug                                                        AS shop,
+                m.subject,
+                m.type,
+                m.sent_at,
+                COALESCE(ms.number_dispatched_emails, 0)                      AS sent,
+                COALESCE(ms.number_dispatched_emails_state_opened, 0)
+                    + COALESCE(ms.number_dispatched_emails_state_clicked, 0)  AS opened,
+                COALESCE(ms.number_dispatched_emails_state_clicked, 0)        AS clicked,
+                COALESCE(ms.number_dispatched_emails_state_unsubscribed, 0)   AS unsubscribed,
+                COALESCE(attr.customers, 0)                                   AS attributed_customers,
+                COALESCE(attr.revenue, 0)                                     AS attributed_revenue,
+                COALESCE(reg.registered, 0)                                   AS prospects_registered
+            FROM mailshots m
+            JOIN shops s ON s.id = m.shop_id
+            LEFT JOIN mailshot_stats ms ON ms.mailshot_id = m.id
+            LEFT JOIN traffic_source_campaigns c ON c.reference = 'mailshot-' || m.id::text
+            LEFT JOIN LATERAL (
+                SELECT SUM(p.share)                    AS customers,
+                       SUM(p.share * cs.sales_all)     AS revenue
+                FROM model_has_traffic_sources p
+                JOIN customer_stats cs ON cs.customer_id = p.model_id
+                WHERE p.model_type = 'Customer'
+                  AND p.traffic_source_campaign_id = c.id
+            ) attr ON true
+            LEFT JOIN LATERAL (
+                SELECT COUNT(*) AS registered
+                FROM model_has_traffic_sources p
+                JOIN prospects pr ON pr.id = p.model_id
+                WHERE p.model_type = 'Prospect'
+                  AND p.traffic_source_campaign_id = c.id
+                  AND pr.customer_id IS NOT NULL
+            ) reg ON true
+            WHERE m.type IN ('newsletter', 'marketing', 'invite')
+        ");
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS marketing_mailshot_performance');
+        DB::statement('DROP VIEW IF EXISTS marketing_channel_performance');
+    }
+};

--- a/database/migrations/2026_08_07_000000_add_traffic_source_index_to_model_has_traffic_sources.php
+++ b/database/migrations/2026_08_07_000000_add_traffic_source_index_to_model_has_traffic_sources.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * TrafficSourceHydrateCustomers aggregates by traffic_source_id + model_type, and the only
+     * existing index leads on model_type/model_id, so every hydrator run walked the whole pivot.
+     * The hydrator fires on every registration, order cancel and email-click recalculation.
+     */
+    public function up(): void
+    {
+        Schema::table('model_has_traffic_sources', function (Blueprint $table) {
+            $table->index(['traffic_source_id', 'model_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('model_has_traffic_sources', function (Blueprint $table) {
+            $table->dropIndex(['traffic_source_id', 'model_type']);
+        });
+    }
+};

--- a/database/migrations/2026_08_07_001000_allow_campaign_rows_in_model_has_traffic_sources.php
+++ b/database/migrations/2026_08_07_001000_allow_campaign_rows_in_model_has_traffic_sources.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * One pivot row per (model, source) forced multiple campaigns of the same source to collapse
+     * into a single row with a null campaign, which made the customers who click more than one
+     * mailshot - the most engaged ones - invisible to every per-campaign report. The unique key now
+     * includes the campaign, expressed through COALESCE so two campaign-less rows still collide.
+     *
+     * traffic_source_costs gets the same treatment: updateOrCreate alone cannot stop a concurrent
+     * import duplicating a day's spend, and Postgres treats NULL campaigns as distinct in a plain
+     * unique constraint.
+     */
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE model_has_traffic_sources DROP CONSTRAINT IF EXISTS model_has_traffic_sources_model_type_model_id_traffic_source_id');
+        DB::statement('DROP INDEX IF EXISTS model_has_traffic_sources_model_type_model_id_traffic_source_id');
+        DB::statement('
+            CREATE UNIQUE INDEX model_has_traffic_sources_model_source_campaign_unique
+            ON model_has_traffic_sources (model_type, model_id, traffic_source_id, COALESCE(traffic_source_campaign_id, 0))
+        ');
+
+        DB::statement('
+            CREATE UNIQUE INDEX traffic_source_costs_source_campaign_date_unique
+            ON traffic_source_costs (traffic_source_id, COALESCE(traffic_source_campaign_id, 0), date)
+        ');
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS traffic_source_costs_source_campaign_date_unique');
+        DB::statement('DROP INDEX IF EXISTS model_has_traffic_sources_model_source_campaign_unique');
+        DB::statement('
+            CREATE UNIQUE INDEX model_has_traffic_sources_model_type_model_id_traffic_source_id
+            ON model_has_traffic_sources (model_type, model_id, traffic_source_id)
+        ');
+    }
+};

--- a/resources/js/Components/DataDisplay/MarketingOverview.vue
+++ b/resources/js/Components/DataDisplay/MarketingOverview.vue
@@ -1,0 +1,191 @@
+<!--
+  - Author: Raul Perusquia <raul@inikoo.com>
+  - Created: Thu, 06 Aug 2026
+  - Copyright (c) 2026, Raul A Perusquia Flores
+  -->
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { Link } from '@inertiajs/vue3'
+import { useLocaleStore } from '@/Stores/locale'
+import { routeType } from '@/types/route'
+import { route } from 'ziggy-js'
+import { trans } from 'laravel-vue-i18n'
+
+const props = defineProps<{
+    overview: {
+        currency_code: string
+        totals: {
+            spend: number
+            revenue: number
+            registrations: number
+            purchases: number
+            roas: number | null
+            cac: number | null
+        }
+        channels: {
+            name: string
+            type: string
+            spend: number
+            revenue: number
+            registrations: number
+            roas: number | null
+        }[]
+        spend_by_day: { date: string, amount: number }[]
+        traffic_sources_route: routeType
+    }
+}>()
+
+const locale = useLocaleStore()
+const money = (value: number) => locale.currencyFormat(props.overview.currency_code, value)
+
+/* Series colors: categorical slots 1 (revenue) and 2 (spend) of the validated palette. */
+const REVENUE_COLOR = '#2a78d6'
+const SPEND_COLOR = '#eb6834'
+
+const maxBarValue = computed(() =>
+    Math.max(1, ...props.overview.channels.flatMap(c => [c.spend, c.revenue]))
+)
+const barWidth = (value: number) => `${Math.max(value > 0 ? 1.2 : 0, (value / maxBarValue.value) * 100)}%`
+
+const hoveredChannel = ref<string | null>(null)
+
+/* 30 days of spend folded into a 30-point sparkline path on a fixed 120x32 viewBox. */
+const sparkline = computed(() => {
+    const days = props.overview.spend_by_day
+    if (days.length < 2) return null
+
+    const max = Math.max(...days.map(d => d.amount), 1)
+    const stepX = 120 / (days.length - 1)
+    const y = (amount: number) => 29 - (amount / max) * 26
+
+    return {
+        path: days.map((d, i) => `${i === 0 ? 'M' : 'L'}${(i * stepX).toFixed(1)},${y(d.amount).toFixed(1)}`).join(' '),
+        endX: 120,
+        endY: y(days[days.length - 1].amount),
+    }
+})
+
+const roasIsGood = computed(() => (props.overview.totals.roas ?? 0) >= 1)
+</script>
+
+<template>
+    <div class="px-4 py-5 md:px-6 space-y-6">
+
+        <!-- KPI row: ROAS is the hero, everything else supports it -->
+        <div class="grid grid-cols-2 lg:grid-cols-3 gap-px rounded-xl overflow-hidden bg-gray-200 ring-1 ring-gray-200">
+            <div class="col-span-2 lg:col-span-1 lg:row-span-2 bg-white p-5 flex flex-col justify-center items-start">
+                <div class="text-xs text-gray-500">{{ trans('Return on ad spend') }}</div>
+                <template v-if="overview.totals.roas !== null">
+                    <div class="mt-1 text-5xl font-semibold tracking-tight"
+                        :class="roasIsGood ? 'text-[#006300]' : 'text-[#d03b3b]'">
+                        {{ overview.totals.roas.toFixed(2) }}<span class="text-3xl">×</span>
+                    </div>
+                    <div class="mt-1 text-xs text-gray-500">
+                        {{ roasIsGood ? '▲' : '▼' }}
+                        {{ roasIsGood ? trans('every unit spent comes back') : trans('spend is not paying back yet') }}
+                    </div>
+                </template>
+                <template v-else>
+                    <div class="mt-1 text-5xl font-semibold tracking-tight text-gray-300">—</div>
+                    <div class="mt-1 text-xs text-gray-400">{{ trans('no ad spend recorded') }}</div>
+                </template>
+            </div>
+
+            <div class="bg-white p-5">
+                <div class="text-xs text-gray-500">{{ trans('Ad spend') }}</div>
+                <div class="mt-1 flex items-end justify-between gap-2">
+                    <div class="text-2xl font-medium text-gray-800">{{ money(overview.totals.spend) }}</div>
+                    <svg v-if="sparkline" viewBox="0 0 124 32" class="w-24 h-8 shrink-0" aria-hidden="true">
+                        <path :d="sparkline.path" fill="none" stroke="#c3c2b7" stroke-width="2"
+                            stroke-linecap="round" stroke-linejoin="round" />
+                        <circle :cx="sparkline.endX" :cy="sparkline.endY" r="4" :fill="SPEND_COLOR"
+                            stroke="#ffffff" stroke-width="2" />
+                    </svg>
+                </div>
+                <div v-if="sparkline" class="mt-0.5 text-xs text-gray-400">{{ trans('last 30 days') }}</div>
+            </div>
+
+            <div class="bg-white p-5">
+                <div class="text-xs text-gray-500">{{ trans('Attributed revenue') }}</div>
+                <div class="mt-1 text-2xl font-medium text-gray-800">{{ money(overview.totals.revenue) }}</div>
+            </div>
+
+            <div class="bg-white p-5">
+                <div class="text-xs text-gray-500">{{ trans('Cost per customer') }}</div>
+                <div class="mt-1 text-2xl font-medium text-gray-800">
+                    {{ overview.totals.cac !== null ? money(overview.totals.cac) : '—' }}
+                </div>
+            </div>
+
+            <div class="bg-white p-5">
+                <div class="text-xs text-gray-500">{{ trans('Attributed customers') }}</div>
+                <div class="mt-1 text-2xl font-medium text-gray-800">
+                    {{ locale.number(overview.totals.registrations) }}
+                    <span class="text-sm text-gray-400">· {{ locale.number(overview.totals.purchases) }} {{ trans('orders') }}</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Channel performance: spend vs revenue, one pair of bars per source -->
+        <div class="rounded-xl ring-1 ring-gray-200 bg-white p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <span class="text-sm font-medium text-gray-800">{{ trans('Channel performance') }}</span>
+                    <span class="ml-2 text-xs text-gray-400">{{ trans('all time, shop currency') }}</span>
+                </div>
+                <div class="flex items-center gap-4 text-xs text-gray-500">
+                    <span class="flex items-center gap-1.5">
+                        <span class="w-2.5 h-2.5 rounded-sm" :style="{ background: REVENUE_COLOR }" />{{ trans('Revenue') }}
+                    </span>
+                    <span class="flex items-center gap-1.5">
+                        <span class="w-2.5 h-2.5 rounded-sm" :style="{ background: SPEND_COLOR }" />{{ trans('Spend') }}
+                    </span>
+                </div>
+            </div>
+
+            <div v-if="overview.channels.length" class="mt-4 space-y-1">
+                <Link v-for="channel in overview.channels" :key="channel.type"
+                    :href="route(overview.traffic_sources_route.name, overview.traffic_sources_route.parameters)"
+                    class="relative grid grid-cols-[8rem_1fr_4.5rem] md:grid-cols-[11rem_1fr_5rem] items-center gap-x-3 rounded-lg px-2 py-2 hover:bg-gray-50"
+                    @mouseenter="hoveredChannel = channel.type" @mouseleave="hoveredChannel = null">
+
+                    <div class="text-sm text-gray-700 truncate">{{ channel.name }}</div>
+
+                    <div class="space-y-0.5">
+                        <div class="flex items-center gap-2">
+                            <div class="h-2.5 rounded-r bg-[#2a78d6] min-w-0"
+                                :style="{ width: barWidth(channel.revenue) }" />
+                            <span v-if="channel.revenue > 0"
+                                class="text-xs text-gray-500 tabular-nums whitespace-nowrap">{{ money(channel.revenue) }}</span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <div class="h-2.5 rounded-r bg-[#eb6834] min-w-0"
+                                :style="{ width: barWidth(channel.spend) }" />
+                            <span v-if="channel.spend > 0"
+                                class="text-xs text-gray-500 tabular-nums whitespace-nowrap">{{ money(channel.spend) }}</span>
+                        </div>
+                    </div>
+
+                    <div class="text-right text-sm tabular-nums"
+                        :class="channel.roas === null ? 'text-gray-300' : channel.roas >= 1 ? 'text-[#006300]' : 'text-[#d03b3b]'">
+                        {{ channel.roas !== null ? channel.roas.toFixed(2) + '×' : '—' }}
+                    </div>
+
+                    <div v-if="hoveredChannel === channel.type"
+                        class="absolute left-2 -top-9 z-10 rounded-md bg-gray-900 px-2.5 py-1.5 text-xs text-white shadow-lg pointer-events-none whitespace-nowrap">
+                        {{ channel.name }} · {{ locale.number(channel.registrations) }} {{ trans('customers') }}
+                        · {{ trans('spend') }} {{ money(channel.spend) }} · {{ trans('revenue') }} {{ money(channel.revenue) }}
+                    </div>
+                </Link>
+            </div>
+
+            <div v-else class="mt-4 py-8 text-center">
+                <div class="text-sm text-gray-500">{{ trans('No channel activity yet') }}</div>
+                <div class="mt-1 text-xs text-gray-400">
+                    {{ trans('Attribution fills this in as visitors register and ad spend is imported') }}
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/DataDisplay/MarketingOverview.vue
+++ b/resources/js/Components/DataDisplay/MarketingOverview.vue
@@ -158,8 +158,8 @@ const typeLabel: Record<string, string> = {
             <div class="bg-white p-5">
                 <div class="text-xs text-gray-500">{{ trans('Attributed customers') }}</div>
                 <div class="mt-1 text-2xl font-medium text-gray-800">
-                    {{ locale.number(overview.totals.registrations) }}
-                    <span class="text-sm text-gray-400">· {{ locale.number(overview.totals.purchases) }} {{ trans('orders') }}</span>
+                    {{ fmtShare(overview.totals.registrations) }}
+                    <span class="text-sm text-gray-400">· {{ fmtShare(overview.totals.purchases) }} {{ trans('orders') }}</span>
                 </div>
             </div>
         </div>

--- a/resources/js/Components/DataDisplay/MarketingOverview.vue
+++ b/resources/js/Components/DataDisplay/MarketingOverview.vue
@@ -32,7 +32,33 @@ const props = defineProps<{
             roas: number | null
         }[]
         spend_by_day: { date: string, amount: number }[]
+        email: {
+            totals: {
+                sent: number
+                opened: number
+                clicked: number
+                unsubscribed: number
+                estimated_cost: number
+                attributed_revenue: number
+                attributed_customers: number
+            }
+            mailshots: {
+                id: number
+                subject: string
+                type: string
+                sent_at: string | null
+                sent: number
+                opened: number
+                clicked: number
+                unsubscribed: number
+                estimated_cost: number
+                attributed_revenue: number
+                attributed_customers: number
+                prospects_registered: number
+            }[]
+        }
         traffic_sources_route: routeType
+        mailshots_route: routeType
     }
 }>()
 
@@ -67,6 +93,14 @@ const sparkline = computed(() => {
 })
 
 const roasIsGood = computed(() => (props.overview.totals.roas ?? 0) >= 1)
+
+const pct = (part: number, whole: number) => whole > 0 ? `${((part / whole) * 100).toFixed(1)}%` : '—'
+
+const typeLabel: Record<string, string> = {
+    newsletter: trans('Newsletter'),
+    marketing: trans('Mailshot'),
+    invite: trans('Prospects'),
+}
 </script>
 
 <template>
@@ -185,6 +219,94 @@ const roasIsGood = computed(() => (props.overview.totals.roas ?? 0) >= 1)
                 <div class="mt-1 text-xs text-gray-400">
                     {{ trans('Attribution fills this in as visitors register and ad spend is imported') }}
                 </div>
+            </div>
+        </div>
+
+        <!-- Email marketing: does what we send earn sales, or just unsubscribes? -->
+        <div v-if="overview.email" class="rounded-xl ring-1 ring-gray-200 bg-white p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <span class="text-sm font-medium text-gray-800">{{ trans('Email marketing') }}</span>
+                    <span class="ml-2 text-xs text-gray-400">{{ trans('recent mailshots · cost estimated from SES') }}</span>
+                </div>
+                <Link :href="route(overview.mailshots_route.name, overview.mailshots_route.parameters)"
+                    class="text-xs text-gray-500 hover:text-gray-800">{{ trans('All mailshots') }} →</Link>
+            </div>
+
+            <div class="mt-4 flex flex-wrap gap-x-8 gap-y-2">
+                <div>
+                    <span class="text-xs text-gray-500">{{ trans('Sent') }}</span>
+                    <div class="text-sm text-gray-800 tabular-nums">{{ locale.number(overview.email.totals.sent) }}</div>
+                </div>
+                <div>
+                    <span class="text-xs text-gray-500">{{ trans('Opened') }}</span>
+                    <div class="text-sm text-gray-800 tabular-nums">{{ pct(overview.email.totals.opened, overview.email.totals.sent) }}</div>
+                </div>
+                <div>
+                    <span class="text-xs text-gray-500">{{ trans('Clicked') }}</span>
+                    <div class="text-sm text-gray-800 tabular-nums">{{ pct(overview.email.totals.clicked, overview.email.totals.sent) }}</div>
+                </div>
+                <div>
+                    <span class="text-xs text-gray-500">{{ trans('Unsubscribed') }}</span>
+                    <div class="text-sm text-gray-800 tabular-nums">{{ locale.number(overview.email.totals.unsubscribed) }}</div>
+                </div>
+                <div>
+                    <span class="text-xs text-gray-500">{{ trans('Est. cost') }}</span>
+                    <div class="text-sm text-gray-800 tabular-nums">{{ money(overview.email.totals.estimated_cost) }}</div>
+                </div>
+                <div>
+                    <span class="text-xs text-gray-500">{{ trans('Attributed revenue') }}</span>
+                    <div class="text-sm tabular-nums"
+                        :class="overview.email.totals.attributed_revenue >= overview.email.totals.estimated_cost ? 'text-[#006300]' : 'text-[#d03b3b]'">
+                        {{ money(overview.email.totals.attributed_revenue) }}
+                    </div>
+                </div>
+            </div>
+
+            <table v-if="overview.email.mailshots.length" class="mt-4 w-full text-xs">
+                <thead>
+                    <tr class="text-gray-400 border-b border-gray-100">
+                        <th class="text-left font-normal py-1.5 pr-2">{{ trans('Mailshot') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Sent') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Opened') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Clicked') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Unsub') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Est. cost') }}</th>
+                        <th class="text-right font-normal py-1.5 pl-2">{{ trans('Result') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="mailshot in overview.email.mailshots" :key="mailshot.id"
+                        class="border-b border-gray-50 text-gray-600">
+                        <td class="py-2 pr-2">
+                            <div class="flex items-center gap-2 min-w-0">
+                                <span class="truncate max-w-[16rem] text-gray-700">{{ mailshot.subject }}</span>
+                                <span class="shrink-0 rounded px-1.5 py-px bg-gray-100 text-gray-500">{{ typeLabel[mailshot.type] ?? mailshot.type }}</span>
+                            </div>
+                            <div v-if="mailshot.sent_at" class="text-gray-400">{{ mailshot.sent_at }}</div>
+                        </td>
+                        <td class="text-right px-2 tabular-nums">{{ locale.number(mailshot.sent) }}</td>
+                        <td class="text-right px-2 tabular-nums">{{ pct(mailshot.opened, mailshot.sent) }}</td>
+                        <td class="text-right px-2 tabular-nums">{{ pct(mailshot.clicked, mailshot.sent) }}</td>
+                        <td class="text-right px-2 tabular-nums">{{ mailshot.unsubscribed > 0 ? locale.number(mailshot.unsubscribed) : '—' }}</td>
+                        <td class="text-right px-2 tabular-nums">{{ money(mailshot.estimated_cost) }}</td>
+                        <td class="text-right pl-2 tabular-nums whitespace-nowrap">
+                            <template v-if="mailshot.type === 'invite'">
+                                {{ mailshot.prospects_registered }} {{ trans('registered') }}
+                            </template>
+                            <template v-else-if="mailshot.attributed_revenue > 0">
+                                {{ money(mailshot.attributed_revenue) }}
+                            </template>
+                            <template v-else>
+                                <span class="text-gray-300">—</span>
+                            </template>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div v-else class="mt-4 py-6 text-center text-xs text-gray-400">
+                {{ trans('No mailshots sent yet') }}
             </div>
         </div>
     </div>

--- a/resources/js/Components/DataDisplay/MarketingOverview.vue
+++ b/resources/js/Components/DataDisplay/MarketingOverview.vue
@@ -96,6 +96,9 @@ const roasIsGood = computed(() => (props.overview.totals.roas ?? 0) >= 1)
 
 const pct = (part: number, whole: number) => whole > 0 ? `${((part / whole) * 100).toFixed(1)}%` : '—'
 
+/* Registrations are share-weighted, so a channel can legitimately hold 12.5 of them. */
+const fmtShare = (value: number) => Number.isInteger(value) ? locale.number(value) : value.toFixed(1)
+
 const typeLabel: Record<string, string> = {
     newsletter: trans('Newsletter'),
     marketing: trans('Mailshot'),
@@ -184,7 +187,12 @@ const typeLabel: Record<string, string> = {
                     class="relative grid grid-cols-[8rem_1fr_4.5rem] md:grid-cols-[11rem_1fr_5rem] items-center gap-x-3 rounded-lg px-2 py-2 hover:bg-gray-50"
                     @mouseenter="hoveredChannel = channel.type" @mouseleave="hoveredChannel = null">
 
-                    <div class="text-sm text-gray-700 truncate">{{ channel.name }}</div>
+                    <div class="min-w-0">
+                        <div class="text-sm text-gray-700 truncate">{{ channel.name }}</div>
+                        <div v-if="channel.registrations > 0" class="text-xs text-gray-400 tabular-nums">
+                            {{ fmtShare(channel.registrations) }} {{ trans('registrations') }}
+                        </div>
+                    </div>
 
                     <div class="space-y-0.5">
                         <div class="flex items-center gap-2">
@@ -208,7 +216,7 @@ const typeLabel: Record<string, string> = {
 
                     <div v-if="hoveredChannel === channel.type"
                         class="absolute left-2 -top-9 z-10 rounded-md bg-gray-900 px-2.5 py-1.5 text-xs text-white shadow-lg pointer-events-none whitespace-nowrap">
-                        {{ channel.name }} · {{ locale.number(channel.registrations) }} {{ trans('customers') }}
+                        {{ channel.name }} · {{ fmtShare(channel.registrations) }} {{ trans('registrations') }}
                         · {{ trans('spend') }} {{ money(channel.spend) }} · {{ trans('revenue') }} {{ money(channel.revenue) }}
                     </div>
                 </Link>

--- a/resources/js/Components/Tables/Grp/Org/CRM/TableTrafficSources.vue
+++ b/resources/js/Components/Tables/Grp/Org/CRM/TableTrafficSources.vue
@@ -45,5 +45,18 @@ function trafficRoute(trafficSource: { slug: string }) {
       <template #cell(total_customer_revenue)="{ item }">
             <div class="text-gray-500">{{ useLocaleStore().currencyFormat(item.currency_code, item.total_customer_revenue) }}</div>
         </template>
+      <template #cell(cost)="{ item }">
+            <div class="text-gray-500">{{ useLocaleStore().currencyFormat(item.currency_code, item.cost) }}</div>
+        </template>
+      <template #cell(roas)="{ item }">
+            <div v-if="item.roas === null" class="text-gray-400">—</div>
+            <div v-else :class="Number(item.roas) >= 1 ? 'text-green-600' : 'text-red-600'">
+                {{ Number(item.roas).toFixed(2) }}×
+            </div>
+        </template>
+      <template #cell(cac)="{ item }">
+            <div v-if="item.cac === null" class="text-gray-400">—</div>
+            <div v-else class="text-gray-500">{{ useLocaleStore().currencyFormat(item.currency_code, item.cac) }}</div>
+        </template>
     </Table>
 </template>

--- a/resources/js/Composables/initialiseIrisVarnish.ts
+++ b/resources/js/Composables/initialiseIrisVarnish.ts
@@ -140,7 +140,9 @@ export const initialiseIrisVarnish = async (layoutStore) => {
   if (varnish?.traffic_source_cookies) {
     for (const [key, cookieData] of Object.entries(varnish.traffic_source_cookies)) {
       if (cookieData?.value) {
-        Cookies.set(key, cookieData.value, cookieData.duration)
+        // js-cookie's third argument is an attributes object; a bare number is silently ignored and
+        // the cookie dies with the session. duration arrives in minutes, expires wants days.
+        Cookies.set(key, cookieData.value, { expires: cookieData.duration / (60 * 24) })
       }
     }
   }

--- a/resources/js/Pages/Grp/Org/Marketing/MarketingDashboard.vue
+++ b/resources/js/Pages/Grp/Org/Marketing/MarketingDashboard.vue
@@ -17,6 +17,7 @@ import type { Component } from 'vue'
 import { PageHeadingTypes } from '@/types/PageHeading'
 import { Tabs as TSTabs } from '@/types/Tabs'
 import SimpleBox from '@/Components/DataDisplay/SimpleBox.vue'
+import MarketingOverview from '@/Components/DataDisplay/MarketingOverview.vue'
 
 const props = defineProps<{
     title: string,
@@ -27,8 +28,9 @@ const props = defineProps<{
         count: number
         icon: string
     }[]
+    marketing_overview: InstanceType<typeof MarketingOverview>['$props']['overview']
 
-    
+
 }>()
 
 const currentTab = ref(props.tabs.current)
@@ -52,5 +54,6 @@ const component = computed(() => {
     <PageHeading :data="pageHead" />
     <Tabs :current="currentTab" :navigation="tabs.navigation" @update:tab="handleTabUpdate" />
     <component :is="component" :data="props[currentTab as keyof typeof props]" :tab="currentTab" />
+    <MarketingOverview v-if="currentTab === 'dashboard' && marketing_overview" :overview="marketing_overview" />
     <SimpleBox v-if="currentTab === 'dashboard' && dashboard_stats" :box_stats="dashboard_stats" />
 </template>

--- a/routes/grp/web/org/shops/shop_root.php
+++ b/routes/grp/web/org/shops/shop_root.php
@@ -52,9 +52,6 @@ Route::prefix('{shop}')->name('show.')
                 Route::prefix("polls")
                     ->name("polls.")
                     ->group(__DIR__ . "/polls.php");
-                Route::prefix("traffic-sources")
-                    ->name("traffic_sources.")
-                    ->group(__DIR__ . "/traffic_sources.php");
                 Route::prefix("platforms")
                     ->name("platforms.")
                     ->group(__DIR__ . "/platforms.php");

--- a/tests/Feature/CRM/EmailMarketingPerformanceTest.php
+++ b/tests/Feature/CRM/EmailMarketingPerformanceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\Comms\Mailshot\StoreMailshot;
+use App\Actions\CRM\TrafficSource\GetShopEmailMarketingPerformance;
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
+use App\Actions\CRM\TrafficSource\RecordEmailClickTouchpoint;
+use App\Enums\Comms\Outbox\OutboxCodeEnum;
+use App\Models\Comms\Mailshot;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+    config()->set('services.ses.cost_per_thousand_usd', 100.0);
+
+    // Pin the USD rate so the estimated-cost assertions never depend on a live exchange fetch.
+    \Illuminate\Support\Facades\Cache::put('current-currency-exchange:USD-GBP', 1.0, 600);
+    \Illuminate\Support\Facades\Cache::put('current-currency-exchange:USD-EUR', 1.0, 600);
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->customer = createCustomer($this->shop);
+    $this->customer->update(['traffic_sources' => null]);
+    $this->customer->trafficSources()->detach();
+
+    $this->googleAds  = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+    $this->newsletter = createTrafficSource($this->shop, 'newsletter', 'Newsletter');
+});
+
+function makeMailshot($shop): Mailshot
+{
+    $outbox = $shop->outboxes()->where('type', OutboxCodeEnum::MARKETING)->first();
+
+    return StoreMailshot::make()->action($outbox, Mailshot::factory()->definition());
+}
+
+it('returns empty performance for a shop that has sent nothing', function () {
+    $performance = GetShopEmailMarketingPerformance::run($this->shop);
+
+    expect($performance['mailshots'])->toBe([]);
+    expect($performance['totals']['sent'])->toBe(0);
+    expect($performance['totals']['attributed_revenue'])->toBe(0.0);
+});
+
+it('splits customer credit between channels so their stats sum to the real totals', function () {
+    $this->customer->update(['traffic_sources' => '1700000000b']);
+    \App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'));
+
+    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update([
+        'sales_all'                      => 1000,
+        'number_orders_state_dispatched' => 4,
+    ]);
+
+    TrafficSourceHydrateCustomers::run($this->googleAds);
+    TrafficSourceHydrateCustomers::run($this->newsletter);
+
+    $googleStats     = $this->googleAds->stats()->first();
+    $newsletterStats = $this->newsletter->stats()->first();
+
+    expect((float) $googleStats->total_customer_revenue)->toBe(500.0);
+    expect((float) $newsletterStats->total_customer_revenue)->toBe(500.0);
+    expect((float) $googleStats->number_customers)->toBe(0.5);
+    expect((float) $googleStats->number_customer_purchases)->toBe(2.0);
+
+    expect(
+        (float) $googleStats->total_customer_revenue + (float) $newsletterStats->total_customer_revenue
+    )->toBe(1000.0);
+});
+
+it('reports engagement, estimated cost and attributed revenue per mailshot', function () {
+    $mailshot = makeMailshot($this->shop);
+
+    $mailshot->stats()->update([
+        'number_dispatched_emails'                    => 2000,
+        'number_dispatched_emails_state_opened'       => 500,
+        'number_dispatched_emails_state_clicked'      => 100,
+        'number_dispatched_emails_state_unsubscribed' => 7,
+    ]);
+
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+
+    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update(['sales_all' => 250]);
+
+    $performance = GetShopEmailMarketingPerformance::run($this->shop);
+
+    expect($performance['mailshots'])->toHaveCount(1);
+    $row = $performance['mailshots'][0];
+
+    expect($row['sent'])->toBe(2000);
+    expect($row['opened'])->toBe(600);
+    expect($row['clicked'])->toBe(100);
+    expect($row['unsubscribed'])->toBe(7);
+    expect($row['estimated_cost'])->toBe(200.0);
+    expect($row['attributed_revenue'])->toBe(250.0);
+    expect($row['attributed_customers'])->toBe(1.0);
+
+    expect($performance['totals']['estimated_cost'])->toBe(200.0);
+    expect($performance['totals']['attributed_revenue'])->toBe(250.0);
+});
+
+it('attributes only the newsletter share of a customer other channels also touched', function () {
+    $mailshot = makeMailshot($this->shop);
+    $mailshot->stats()->update(['number_dispatched_emails' => 100]);
+
+    $this->customer->update(['traffic_sources' => '1700000000b']);
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+
+    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update(['sales_all' => 1000]);
+
+    $performance = GetShopEmailMarketingPerformance::run($this->shop);
+
+    expect($performance['mailshots'][0]['attributed_revenue'])->toBe(500.0);
+    expect($performance['mailshots'][0]['attributed_customers'])->toBe(0.5);
+});
+
+it('counts prospects who clicked a mailshot and later registered', function () {
+    $mailshot = makeMailshot($this->shop);
+    $mailshot->stats()->update(['number_dispatched_emails' => 50]);
+
+    $prospect = \App\Actions\CRM\Prospect\StoreProspect::make()->action(
+        $this->shop,
+        \App\Models\CRM\Prospect::factory()->definition()
+    );
+
+    RecordEmailClickTouchpoint::run($prospect, Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+
+    $performance = GetShopEmailMarketingPerformance::run($this->shop);
+    expect($performance['mailshots'][0]['prospects_registered'])->toBe(0);
+
+    $prospect->update(['customer_id' => $this->customer->id]);
+
+    $performance = GetShopEmailMarketingPerformance::run($this->shop);
+    expect($performance['mailshots'][0]['prospects_registered'])->toBe(1);
+});

--- a/tests/Feature/CRM/EmailMarketingPerformanceTest.php
+++ b/tests/Feature/CRM/EmailMarketingPerformanceTest.php
@@ -199,6 +199,24 @@ it('serves honest share-weighted numbers through the sql views', function () {
     expect((float) $mailshotRow->attributed_customers)->toBe(0.5);
 });
 
+it('keeps repeat clickers visible to every mailshot they clicked', function () {
+    $first  = makeMailshot($this->shop);
+    $second = makeMailshot($this->shop);
+    $first->stats()->update(['number_dispatched_emails' => 10]);
+    $second->stats()->update(['number_dispatched_emails' => 10]);
+
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'), $first);
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-02 10:00:00'), $second);
+
+    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update(['sales_all' => 1000]);
+
+    $performance = collect(GetShopEmailMarketingPerformance::run($this->shop)['mailshots'])->keyBy('id');
+
+    expect($performance[$first->id]['attributed_revenue'])->toBe(500.0);
+    expect($performance[$second->id]['attributed_revenue'])->toBe(500.0);
+    expect($performance[$first->id]['attributed_customers'])->toBe(0.5);
+});
+
 it('counts prospects who clicked a mailshot and later registered', function () {
     $mailshot = makeMailshot($this->shop);
     $mailshot->stats()->update(['number_dispatched_emails' => 50]);

--- a/tests/Feature/CRM/EmailMarketingPerformanceTest.php
+++ b/tests/Feature/CRM/EmailMarketingPerformanceTest.php
@@ -132,6 +132,43 @@ it('attributes only the newsletter share of a customer other channels also touch
     expect($performance['mailshots'][0]['attributed_customers'])->toBe(0.5);
 });
 
+it('credits the mailshot channel with the registration when a prospect converts', function () {
+    createTrafficSource($this->shop, 'organic-google', 'Organic Google');
+
+    $mailshot = makeMailshot($this->shop);
+    $mailshot->stats()->update(['number_dispatched_emails' => 50]);
+
+    $prospect = \App\Actions\CRM\Prospect\StoreProspect::make()->action(
+        $this->shop,
+        array_merge(\App\Models\CRM\Prospect::factory()->definition(), [
+            'email' => 'converting-'.uniqid().'@example.com',
+        ])
+    );
+
+    RecordEmailClickTouchpoint::run($prospect, Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+
+    $customer = \App\Actions\CRM\Customer\StoreCustomer::make()->action(
+        $this->shop,
+        array_merge(\App\Models\CRM\Customer::factory()->definition(), [
+            'email'           => $prospect->email,
+            'traffic_sources' => '1735689600a',
+        ])
+    );
+
+    // StoreCustomer only runs the prospect match on is_aiku shops; invoke it directly here.
+    \App\Actions\CRM\Customer\MatchCustomerProspects::run($customer);
+
+    expect($customer->fresh()->traffic_sources)->toContain('pmailshot-'.$mailshot->id);
+    expect($customer->fresh()->traffic_sources)->toContain('1735689600a');
+
+    $types = $customer->trafficSources()->pluck('type')->all();
+    expect($types)->toContain('newsletter');
+    expect($types)->toContain('organic-google');
+
+    $performance = GetShopEmailMarketingPerformance::run($this->shop);
+    expect($performance['mailshots'][0]['prospects_registered'])->toBe(1);
+});
+
 it('counts prospects who clicked a mailshot and later registered', function () {
     $mailshot = makeMailshot($this->shop);
     $mailshot->stats()->update(['number_dispatched_emails' => 50]);

--- a/tests/Feature/CRM/EmailMarketingPerformanceTest.php
+++ b/tests/Feature/CRM/EmailMarketingPerformanceTest.php
@@ -169,6 +169,36 @@ it('credits the mailshot channel with the registration when a prospect converts'
     expect($performance['mailshots'][0]['prospects_registered'])->toBe(1);
 });
 
+it('serves honest share-weighted numbers through the sql views', function () {
+    $mailshot = makeMailshot($this->shop);
+    $mailshot->stats()->update(['number_dispatched_emails' => 100]);
+
+    $this->customer->update(['traffic_sources' => '1700000000b']);
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+
+    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update(['sales_all' => 1000]);
+    TrafficSourceHydrateCustomers::run($this->googleAds);
+    TrafficSourceHydrateCustomers::run($this->newsletter);
+
+    $channels = collect(DB::select(
+        'SELECT * FROM marketing_channel_performance WHERE shop_id = ?',
+        [$this->shop->id]
+    ))->keyBy('type');
+
+    expect((float) $channels['google-ads']->revenue)->toBe(500.0);
+    expect((float) $channels['newsletter']->revenue)->toBe(500.0);
+    expect((float) $channels['google-ads']->registrations)->toBe(0.5);
+
+    $mailshotRow = collect(DB::select(
+        'SELECT * FROM marketing_mailshot_performance WHERE mailshot_id = ?',
+        [$mailshot->id]
+    ))->first();
+
+    expect((int) $mailshotRow->sent)->toBe(100);
+    expect((float) $mailshotRow->attributed_revenue)->toBe(500.0);
+    expect((float) $mailshotRow->attributed_customers)->toBe(0.5);
+});
+
 it('counts prospects who clicked a mailshot and later registered', function () {
     $mailshot = makeMailshot($this->shop);
     $mailshot->stats()->update(['number_dispatched_emails' => 50]);

--- a/tests/Feature/CRM/EmailMarketingPerformanceTest.php
+++ b/tests/Feature/CRM/EmailMarketingPerformanceTest.php
@@ -199,6 +199,37 @@ it('serves honest share-weighted numbers through the sql views', function () {
     expect((float) $mailshotRow->attributed_customers)->toBe(0.5);
 });
 
+it('folds a second device cookie into the customer journey', function () {
+    createTrafficSource($this->shop, 'organic-google', 'Organic Google');
+
+    // Desktop: registered from a google-ads click.
+    $this->customer->update(['traffic_sources' => '1700000000b']);
+    \App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    // Phone: an organic visit this browser saw but the server never did.
+    \App\Actions\CRM\TrafficSource\SyncCustomerTrafficSourcesFromDevice::run(
+        $this->customer->fresh(),
+        '1700000000b|1700000100a'
+    );
+
+    $customer = $this->customer->fresh();
+    expect($customer->traffic_sources)->toBe('1700000000b|1700000100a');
+
+    $shares = $customer->trafficSources()->get();
+    expect($shares)->toHaveCount(2);
+    expect(round($shares->sum(fn ($row) => (float) $row->pivot->share), 2))->toBe(1.0);
+});
+
+it('does nothing when the device cookie holds nothing new', function () {
+    $this->customer->update(['traffic_sources' => '1700000000b']);
+    \App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+    $updatedAt = $this->customer->fresh()->updated_at;
+
+    \App\Actions\CRM\TrafficSource\SyncCustomerTrafficSourcesFromDevice::run($this->customer->fresh(), '1700000000b');
+
+    expect($this->customer->fresh()->updated_at->eq($updatedAt))->toBeTrue();
+});
+
 it('keeps repeat clickers visible to every mailshot they clicked', function () {
     $first  = makeMailshot($this->shop);
     $second = makeMailshot($this->shop);

--- a/tests/Feature/CRM/TrafficSourceAttributionTest.php
+++ b/tests/Feature/CRM/TrafficSourceAttributionTest.php
@@ -84,7 +84,7 @@ it('links the matching campaign reference to the pivot record', function () {
     expect($pivot->traffic_source_campaign_id)->toBe($campaign->id);
 });
 
-it('keeps the full credit on the source when two of its campaigns are both credited', function () {
+it('keeps a row per campaign with the source credit summing to one', function () {
     $trafficSource = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
 
     $campaigns = collect(['spring', 'summer'])->map(fn (string $season) => TrafficSourceCampaign::create([
@@ -101,11 +101,30 @@ it('keeps the full credit on the source when two of its campaigns are both credi
         ])
     );
 
-    expect($customer->trafficSources()->count())->toBe(1);
+    $rows = $customer->trafficSources()->get();
 
-    $pivot = $customer->trafficSources()->first()->pivot;
-    expect((float) $pivot->share)->toBe(1.0);
-    expect($pivot->traffic_source_campaign_id)->toBeNull();
+    expect($rows)->toHaveCount(2);
+    expect($rows->pluck('pivot.traffic_source_campaign_id')->sort()->values()->all())
+        ->toBe([$campaigns[0]->id, $campaigns[1]->id]);
+    expect(round($rows->sum(fn ($row) => (float) $row->pivot->share), 2))->toBe(1.0);
+});
+
+it('creates the campaign from a touch when the reference is new', function () {
+    createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+
+    $reference = 'auto-'.uniqid();
+
+    $customer = StoreCustomer::make()->action(
+        $this->shop,
+        array_merge(Customer::factory()->definition(), [
+            'traffic_sources' => '1700000000b'.$reference,
+        ])
+    );
+
+    $campaign = TrafficSourceCampaign::where('reference', $reference)->first();
+
+    expect($campaign)->not->toBeNull();
+    expect($customer->trafficSources()->first()->pivot->traffic_source_campaign_id)->toBe($campaign->id);
 });
 
 it('does not attach anything when the abbreviation does not match a known traffic source type', function () {

--- a/tests/Feature/CRM/TrafficSourceAttributionTest.php
+++ b/tests/Feature/CRM/TrafficSourceAttributionTest.php
@@ -109,10 +109,10 @@ it('keeps a row per campaign with the source credit summing to one', function ()
     expect(round($rows->sum(fn ($row) => (float) $row->pivot->share), 2))->toBe(1.0);
 });
 
-it('creates the campaign from a touch when the reference is new', function () {
+it('creates the campaign from a touch when the reference looks like an ad platform id', function () {
     createTrafficSource($this->shop, 'google-ads', 'Google Ads');
 
-    $reference = 'auto-'.uniqid();
+    $reference = (string) random_int(10000000000, 99999999999);
 
     $customer = StoreCustomer::make()->action(
         $this->shop,
@@ -125,6 +125,25 @@ it('creates the campaign from a touch when the reference is new', function () {
 
     expect($campaign)->not->toBeNull();
     expect($customer->trafficSources()->first()->pivot->traffic_source_campaign_id)->toBe($campaign->id);
+});
+
+it('refuses to mint a campaign from a non-numeric reference', function () {
+    createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+
+    $reference = 'crafted-'.uniqid();
+
+    $customer = StoreCustomer::make()->action(
+        $this->shop,
+        array_merge(Customer::factory()->definition(), [
+            'traffic_sources' => '1700000000b'.$reference,
+        ])
+    );
+
+    expect(TrafficSourceCampaign::where('reference', $reference)->exists())->toBeFalse();
+
+    $pivot = $customer->trafficSources()->first()->pivot;
+    expect($pivot->traffic_source_campaign_id)->toBeNull();
+    expect((float) $pivot->share)->toBe(1.0);
 });
 
 it('does not attach anything when the abbreviation does not match a known traffic source type', function () {

--- a/tests/Feature/CRM/TrafficSourceCostImportTest.php
+++ b/tests/Feature/CRM/TrafficSourceCostImportTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Models\CRM\TrafficSourceCampaign;
+use App\Models\CRM\TrafficSourceCost;
+use Illuminate\Support\Facades\Artisan;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->googleAds = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+    $this->metaAds   = createTrafficSource($this->shop, 'meta-ads', 'Meta Ads');
+
+    TrafficSourceCost::where('shop_id', $this->shop->id)->delete();
+});
+
+function costCsvFile(array $rows): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'costs').'.csv';
+    file_put_contents($path, "shop,source,campaign,date,amount,currency\n".implode("\n", $rows)."\n");
+
+    return $path;
+}
+
+function importCosts(array $rows, array $options = []): int
+{
+    return Artisan::call('traffic-source:import-costs', array_merge(
+        ['file' => costCsvFile($rows)],
+        $options
+    ));
+}
+
+it('imports spend from a csv', function () {
+    $currency = $this->shop->currency->code;
+
+    $exit = importCosts([
+        "{$this->shop->slug},google-ads,,2026-08-01,153.22,{$currency}",
+        "{$this->shop->slug},meta-ads,,2026-08-01,88.40,{$currency}",
+    ]);
+
+    expect($exit)->toBe(0);
+
+    $costs = TrafficSourceCost::where('shop_id', $this->shop->id)->get();
+    expect($costs)->toHaveCount(2);
+    expect((float) $costs->firstWhere('traffic_source_id', $this->googleAds->id)->source_amount)->toBe(153.22);
+});
+
+it('matches a campaign by the reference the touch history already stores', function () {
+    $campaign = TrafficSourceCampaign::create([
+        'traffic_source_id' => $this->googleAds->id,
+        'reference'         => 'ref-'.uniqid(),
+        'name'              => 'August Push',
+        'type'              => 'search',
+    ]);
+
+    importCosts([
+        "{$this->shop->slug},google-ads,{$campaign->reference},2026-08-01,25.00,{$this->shop->currency->code}",
+    ]);
+
+    $cost = TrafficSourceCost::where('shop_id', $this->shop->id)->first();
+    expect($cost->traffic_source_campaign_id)->toBe($campaign->id);
+});
+
+it('rejects the row and reports failure when the traffic source is unknown', function () {
+    $exit = importCosts([
+        "{$this->shop->slug},not-a-real-source,,2026-08-01,10.00,{$this->shop->currency->code}",
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(TrafficSourceCost::where('shop_id', $this->shop->id)->count())->toBe(0);
+});
+
+it('rejects a bad row without discarding the good ones around it', function () {
+    $currency = $this->shop->currency->code;
+
+    $exit = importCosts([
+        "{$this->shop->slug},google-ads,,2026-08-01,10.00,{$currency}",
+        "{$this->shop->slug},nonsense,,2026-08-01,10.00,{$currency}",
+        "{$this->shop->slug},meta-ads,,2026-08-01,20.00,{$currency}",
+    ]);
+
+    expect($exit)->toBe(1);
+    expect(TrafficSourceCost::where('shop_id', $this->shop->id)->count())->toBe(2);
+});
+
+it('writes nothing in dry run mode', function () {
+    $exit = importCosts(
+        ["{$this->shop->slug},google-ads,,2026-08-01,10.00,{$this->shop->currency->code}"],
+        ['--dry-run' => true]
+    );
+
+    expect($exit)->toBe(0);
+    expect(TrafficSourceCost::where('shop_id', $this->shop->id)->count())->toBe(0);
+});
+
+it('is safe to import the same report twice', function () {
+    $row = "{$this->shop->slug},google-ads,,2026-08-01,153.22,{$this->shop->currency->code}";
+
+    importCosts([$row]);
+    importCosts([$row]);
+
+    expect(TrafficSourceCost::where('shop_id', $this->shop->id)->count())->toBe(1);
+});
+
+it('fails clearly when the header is missing a column', function () {
+    $path = tempnam(sys_get_temp_dir(), 'costs').'.csv';
+    file_put_contents($path, "shop,source,date,amount\nuk,google-ads,2026-08-01,10\n");
+
+    expect(Artisan::call('traffic-source:import-costs', ['file' => $path]))->toBe(1);
+});

--- a/tests/Feature/CRM/TrafficSourceCostTest.php
+++ b/tests/Feature/CRM/TrafficSourceCostTest.php
@@ -8,6 +8,7 @@
 
 /** @noinspection PhpUnhandledExceptionInspection */
 
+use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
 use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCosts;
 use App\Actions\CRM\TrafficSource\StoreTrafficSourceCost;
 use App\Actions\CRM\TrafficSource\UI\IndexTrafficSources;
@@ -160,6 +161,55 @@ it('exposes cost, roas and cac on the shop traffic sources listing', function ()
     expect((float) $row->cost)->toBe(50.0);
     expect((float) $row->roas)->toBe(4.0);
     expect((float) $row->cac)->toBe(12.5);
+});
+
+it('assembles the marketing overview from the stats rollups', function () {
+    $organic = createTrafficSource($this->shop, 'organic-google', 'Organic Google');
+    $organic->stats()->updateOrCreate(
+        ['traffic_source_id' => $organic->id],
+        ['number_customers' => 10, 'total_customer_revenue' => 300.00, 'total_cost' => 0]
+    );
+
+    StoreTrafficSourceCost::run($this->trafficSource, [
+        'date'               => now()->subDays(2)->toDateString(),
+        'source_amount'      => 100.00,
+        'source_currency_id' => $this->currency->id,
+    ]);
+    StoreTrafficSourceCost::run($this->trafficSource, [
+        'date'               => now()->subDay()->toDateString(),
+        'source_amount'      => 100.00,
+        'source_currency_id' => $this->currency->id,
+    ]);
+    TrafficSourceHydrateCosts::run($this->trafficSource);
+    $this->trafficSource->stats()->update([
+        'number_customers'       => 4,
+        'total_customer_revenue' => 500.00,
+    ]);
+
+    $overview = GetShopMarketingOverview::run($this->shop);
+
+    expect($overview['totals']['spend'])->toBe(200.0);
+    expect($overview['totals']['revenue'])->toBe(800.0);
+    expect($overview['totals']['roas'])->toBe(4.0);
+    expect($overview['totals']['cac'])->toBe(round(200 / 14, 2));
+    expect($overview['currency_code'])->toBe($this->currency->code);
+
+    expect($overview['channels'])->toHaveCount(2);
+    expect($overview['channels'][0]['type'])->toBe('google-ads');
+    expect($overview['channels'][0]['roas'])->toBe(2.5);
+    expect($overview['channels'][1]['roas'])->toBeNull();
+
+    expect($overview['spend_by_day'])->toHaveCount(2);
+    expect($overview['spend_by_day'][0]['amount'])->toBe(100.0);
+});
+
+it('reports a null roas and cac in the overview when nothing was spent', function () {
+    $overview = GetShopMarketingOverview::run($this->shop);
+
+    expect($overview['totals']['spend'])->toBe(0.0);
+    expect($overview['totals']['roas'])->toBeNull();
+    expect($overview['totals']['cac'])->toBeNull();
+    expect($overview['spend_by_day'])->toBe([]);
 });
 
 it('reports no roas or cac for a source with no recorded spend', function () {

--- a/tests/Feature/CRM/TrafficSourceCostTest.php
+++ b/tests/Feature/CRM/TrafficSourceCostTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCosts;
+use App\Actions\CRM\TrafficSource\StoreTrafficSourceCost;
+use App\Actions\CRM\TrafficSource\UI\IndexTrafficSources;
+use App\Models\CRM\TrafficSourceCampaign;
+use App\Models\CRM\TrafficSourceCost;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Artisan;
+
+beforeAll(function () {
+    loadDB();
+});
+
+/**
+ * IndexTrafficSources names its paginator after the current route, which does not exist when the
+ * action is called directly rather than through a request.
+ */
+function fakeCurrentRoute(): void
+{
+    $route = (new Route('GET', '/_test', []))->name('test.traffic_sources.index');
+
+    request()->setRouteResolver(fn () => $route);
+}
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->trafficSource = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+    $this->currency      = $this->shop->currency;
+
+    // The shop and traffic source are shared across the tests in this file, so clear anything a
+    // previous test left on them.
+    TrafficSourceCost::where('traffic_source_id', $this->trafficSource->id)->delete();
+    $this->trafficSource->stats()->updateOrCreate(
+        ['traffic_source_id' => $this->trafficSource->id],
+        [
+            'total_cost'                 => 0,
+            'org_total_cost'             => 0,
+            'total_customer_revenue'     => 0,
+            'org_total_customer_revenue' => 0,
+            'number_customers'           => 0,
+        ]
+    );
+});
+
+it('records a cost and rolls it into the traffic source stats', function () {
+    StoreTrafficSourceCost::run($this->trafficSource, [
+        'date'               => '2026-08-01',
+        'source_amount'      => 153.22,
+        'source_currency_id' => $this->currency->id,
+    ]);
+
+    TrafficSourceHydrateCosts::run($this->trafficSource);
+
+    expect((float) $this->trafficSource->stats()->first()->total_cost)->toBe(153.22);
+});
+
+it('keeps the originally billed amount alongside the converted one', function () {
+    $cost = StoreTrafficSourceCost::run($this->trafficSource, [
+        'date'               => '2026-08-01',
+        'source_amount'      => 99.5,
+        'source_currency_id' => $this->currency->id,
+    ]);
+
+    expect((float) $cost->source_amount)->toBe(99.5);
+    expect($cost->source_currency_id)->toBe($this->currency->id);
+    expect((float) $cost->amount)->toBe(99.5);
+});
+
+it('updates rather than duplicates when the same day is imported again', function () {
+    foreach ([100.00, 137.65] as $amount) {
+        StoreTrafficSourceCost::run($this->trafficSource, [
+            'date'               => '2026-08-01',
+            'source_amount'      => $amount,
+            'source_currency_id' => $this->currency->id,
+        ]);
+    }
+
+    $costs = TrafficSourceCost::where('traffic_source_id', $this->trafficSource->id)->get();
+
+    expect($costs)->toHaveCount(1);
+    expect((float) $costs->first()->source_amount)->toBe(137.65);
+});
+
+it('keeps campaign level and source level spend as separate rows for the same day', function () {
+    $campaign = TrafficSourceCampaign::create([
+        'traffic_source_id' => $this->trafficSource->id,
+        'reference'         => 'camp-'.uniqid(),
+        'name'              => 'August Push',
+        'type'              => 'search',
+    ]);
+
+    StoreTrafficSourceCost::run($this->trafficSource, [
+        'date'               => '2026-08-01',
+        'source_amount'      => 40.00,
+        'source_currency_id' => $this->currency->id,
+    ]);
+
+    StoreTrafficSourceCost::run($this->trafficSource, [
+        'date'                       => '2026-08-01',
+        'source_amount'              => 60.00,
+        'source_currency_id'         => $this->currency->id,
+        'traffic_source_campaign_id' => $campaign->id,
+    ]);
+
+    TrafficSourceHydrateCosts::run($this->trafficSource);
+
+    expect(TrafficSourceCost::where('traffic_source_id', $this->trafficSource->id)->count())->toBe(2);
+    expect((float) $this->trafficSource->stats()->first()->total_cost)->toBe(100.0);
+});
+
+it('sums spend across days', function () {
+    foreach (['2026-08-01' => 10.00, '2026-08-02' => 15.50] as $date => $amount) {
+        StoreTrafficSourceCost::run($this->trafficSource, [
+            'date'               => $date,
+            'source_amount'      => $amount,
+            'source_currency_id' => $this->currency->id,
+        ]);
+    }
+
+    TrafficSourceHydrateCosts::run($this->trafficSource);
+
+    expect((float) $this->trafficSource->stats()->first()->total_cost)->toBe(25.5);
+});
+
+it('exposes cost, roas and cac on the shop traffic sources listing', function () {
+    StoreTrafficSourceCost::run($this->trafficSource, [
+        'date'               => '2026-08-01',
+        'source_amount'      => 50.00,
+        'source_currency_id' => $this->currency->id,
+    ]);
+
+    TrafficSourceHydrateCosts::run($this->trafficSource);
+
+    $this->trafficSource->stats()->update([
+        'total_customer_revenue' => 200.00,
+        'number_customers'       => 4,
+    ]);
+
+    fakeCurrentRoute();
+
+    $row = IndexTrafficSources::make()->handle($this->shop)
+        ->firstWhere('id', $this->trafficSource->id);
+
+    expect((float) $row->cost)->toBe(50.0);
+    expect((float) $row->roas)->toBe(4.0);
+    expect((float) $row->cac)->toBe(12.5);
+});
+
+it('reports no roas or cac for a source with no recorded spend', function () {
+    $this->trafficSource->stats()->update([
+        'total_customer_revenue' => 200.00,
+        'number_customers'       => 4,
+    ]);
+
+    fakeCurrentRoute();
+
+    $row = IndexTrafficSources::make()->handle($this->shop)
+        ->firstWhere('id', $this->trafficSource->id);
+
+    expect($row->roas)->toBeNull();
+    expect($row->cac)->toBeNull();
+});

--- a/tests/Unit/Actions/CRM/TrafficSource/MergeTrafficSourceTouchHistoriesTest.php
+++ b/tests/Unit/Actions/CRM/TrafficSource/MergeTrafficSourceTouchHistoriesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 06 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use App\Actions\CRM\TrafficSource\MergeTrafficSourceTouchHistories;
+
+it('interleaves two histories by timestamp', function () {
+    expect(MergeTrafficSourceTouchHistories::run('1700000200pmailshot-9', '1700000100a|1700000300b123'))
+        ->toBe('1700000100a|1700000200pmailshot-9|1700000300b123');
+});
+
+it('drops exact duplicate touches', function () {
+    expect(MergeTrafficSourceTouchHistories::run('1700000100a|1700000200b', '1700000200b'))
+        ->toBe('1700000100a|1700000200b');
+});
+
+it('handles a null side', function () {
+    expect(MergeTrafficSourceTouchHistories::run(null, '1700000100a'))->toBe('1700000100a');
+    expect(MergeTrafficSourceTouchHistories::run('1700000100a', null))->toBe('1700000100a');
+});
+
+it('returns null when both sides are empty', function () {
+    expect(MergeTrafficSourceTouchHistories::run(null, null))->toBeNull();
+    expect(MergeTrafficSourceTouchHistories::run('', ''))->toBeNull();
+});
+
+it('normalises legacy comma separators', function () {
+    expect(MergeTrafficSourceTouchHistories::run('1700000100a,1700000200b', null))
+        ->toBe('1700000100a|1700000200b');
+});

--- a/tests/Unit/Actions/CRM/TrafficSource/SanitizeDeviceTouchesTest.php
+++ b/tests/Unit/Actions/CRM/TrafficSource/SanitizeDeviceTouchesTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use App\Actions\CRM\TrafficSource\SyncCustomerTrafficSourcesFromDevice;
+
+it('passes credible touches through intact', function () {
+    expect(SyncCustomerTrafficSourcesFromDevice::sanitize('1700000000b22872123321|1700000100a'))
+        ->toBe('1700000000b22872123321|1700000100a');
+});
+
+it('drops a forged epoch first touch', function () {
+    expect(SyncCustomerTrafficSourcesFromDevice::sanitize('1a|1700000100b'))
+        ->toBe('1700000100b');
+});
+
+it('drops touches from the future', function () {
+    $future = now()->addYear()->timestamp;
+
+    expect(SyncCustomerTrafficSourcesFromDevice::sanitize("{$future}a|1700000100b"))
+        ->toBe('1700000100b');
+});
+
+it('drops garbage and unknown abbreviations', function () {
+    expect(SyncCustomerTrafficSourcesFromDevice::sanitize('<script>|zzzz|1700000100z|1700000200a'))
+        ->toBe('1700000200a');
+});
+
+it('returns null when nothing survives', function () {
+    expect(SyncCustomerTrafficSourcesFromDevice::sanitize('total|garbage'))->toBeNull();
+    expect(SyncCustomerTrafficSourcesFromDevice::sanitize(null))->toBeNull();
+    expect(SyncCustomerTrafficSourcesFromDevice::sanitize(''))->toBeNull();
+});


### PR DESCRIPTION
Phase 6, first slice: the cost side of marketing attribution.

Phases 1-5 could report how many customers and how much revenue a traffic source produced, but nothing recorded what was **spent** to acquire them — so ROAS and CAC, the questions the feature exists to answer, could not be asked. `IndexTrafficSources` has carried an empty `Cost` column since it was written.

## What this adds

**`traffic_source_costs`** — one row per traffic source (or campaign) per day.

- Spend is converted at the **historic rate of the day it was spent**, not today's, so importing a report late doesn't restate a closed period every time the exchange rate moves.
- The originally billed `source_amount` and `source_currency_id` are kept, so a figure can always be traced back to what the platform actually charged, independent of the rate applied.
- Re-importing a day **updates** rather than duplicates — advertisers routinely re-export once late conversions have settled, and the second export is the more accurate one.
- Campaign-level and source-level spend for the same day coexist as separate rows.

**`traffic-source:import-costs`** — CSV import:

```
shop,source,campaign,date,amount,currency
uk,google-ads,22872123321,2026-08-01,153.22,GBP
uk,meta-ads,,2026-08-01,88.40,GBP
```

`campaign` is optional and matches `traffic_source_campaigns.reference`, which is exactly what the touch history already stores — so a Google Ads campaign id pasted straight from the platform lines up with the attribution data with no mapping step. A bad row is reported with its line number and rejected without discarding the good rows around it. `--dry-run` validates without writing.

**ROAS and CAC on the existing listing**, plus the `Cost` column finally populated.

## Currency correctness

The organisation-scoped listing labels its figures with the organisation's currency, but `total_customer_revenue` is summed from `customer_stats.sales_all` and is in the **shop's**. Pairing that with an organisation-currency cost would have produced a ratio between two different currencies.

So this adds `org_total_customer_revenue`, hydrated from the `sales_org_currency_all` column that already exists on `customer_stats`, and the listing selects the cost/revenue pair matching whichever currency it joined. This also fixes a pre-existing mislabelling on that screen.

ROAS and CAC are `null` rather than `0` where there is no spend — permanently the case for organic sources — so the table renders a dash instead of claiming a return of zero.

## Deliberately not included

- **Upload-tracked import.** The `Upload` machinery records per-row audit data nothing reads yet, and every existing importer using it (`ImportCustomers`, `ImportGuests`, `ImportRawMaterial`, `ImportArtefact`) is already broken against `StoreUpload`'s current signature — they pass `($file, Model::class)` to `(Group|Organisation|Shop $parent, array $modelData)`. Worth a separate fix. A plain command avoids inheriting that.
- **Platform-native parsers** (Google Ads / Microsoft / Meta exports). Generic CSV first; parsers can be added without touching the storage model.
- Marketing overview dashboard, customer journey timeline, data-quality dashboard, and the full filter set — the rest of Phase 6.

## Tests

- `tests/Feature/CRM/TrafficSourceCostTest.php` — storage, hydration, dedupe, campaign/source separation, and the listing's cost/ROAS/CAC values
- `tests/Feature/CRM/TrafficSourceCostImportTest.php` — CSV import, campaign matching, per-row rejection, dry run, repeat import, malformed header

14 tests, all passing locally. Not verified in the browser: the Vue column rendering is untested, since checking it needs the new migrations run against a dev database.