### PR TITLE
📅 feat: period-scoped marketing metrics (ROAS by date range)

### DIFF
--- a/app/Actions/CRM/TrafficSource/GetShopEmailMarketingPerformance.php
+++ b/app/Actions/CRM/TrafficSource/GetShopEmailMarketingPerformance.php
@@ -10,6 +10,7 @@ namespace App\Actions\CRM\TrafficSource;
 
 use App\Actions\Helpers\CurrencyExchange\GetCurrencyExchange;
 use App\Enums\Comms\Mailshot\MailshotTypeEnum;
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
 use App\Models\Catalogue\Shop;
 use App\Models\Comms\Mailshot;
 use App\Models\CRM\TrafficSourceCampaign;
@@ -35,14 +36,19 @@ class GetShopEmailMarketingPerformance
      *
      * @return array{totals: array{sent: int, opened: int, clicked: int, unsubscribed: int, estimated_cost: float, attributed_revenue: float, attributed_customers: float}, mailshots: array<int, array{id: int, subject: string, type: string, sent_at: string|null, sent: int, opened: int, clicked: int, unsubscribed: int, estimated_cost: float, attributed_revenue: float, attributed_customers: float, prospects_registered: int}>}
      */
-    public function handle(Shop $shop, int $limit = 8): array
+    public function handle(Shop $shop, MarketingPeriodEnum $period = MarketingPeriodEnum::LAST_30, int $limit = 8): array
     {
+        $from = $period->startsAt();
+
         $usdToShop = $this->usdToShopRate($shop);
         $costPerEmail = ((float) config('services.ses.cost_per_thousand_usd')) / 1000 * $usdToShop;
 
+        /* Filtered by when the mailshot was sent, not when its clicks earned revenue: the question
+           this panel answers is whether the emails sent in a period paid for themselves. */
         $mailshots = Mailshot::where('shop_id', $shop->id)
             ->whereIn('type', [MailshotTypeEnum::NEWSLETTER, MailshotTypeEnum::MARKETING, MailshotTypeEnum::INVITE])
             ->whereHas('stats', fn ($query) => $query->where('number_dispatched_emails', '>', 0))
+            ->when($from, fn ($query) => $query->whereRaw('COALESCE(sent_at, created_at) >= ?', [$from]))
             ->with('stats')
             ->orderByRaw('COALESCE(sent_at, created_at) DESC, id DESC')
             ->limit($limit)

--- a/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
+++ b/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
@@ -8,8 +8,9 @@
 
 namespace App\Actions\CRM\TrafficSource;
 
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
 use App\Models\Catalogue\Shop;
-use App\Models\CRM\TrafficSourceCost;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -18,76 +19,139 @@ class GetShopMarketingOverview
     use AsAction;
 
     /**
-     * Assembles the numbers the marketing dashboard leads with: total attributed revenue, total ad
-     * spend, the ROAS and CAC they imply, and the per-channel spend/revenue comparison. Everything is
-     * read from the traffic_source_stats rollups the hydrators maintain, so this is a handful of rows,
-     * never an aggregate over customers or orders.
+     * Assembles the marketing dashboard's numbers for a period: attributed revenue, ad spend, and the
+     * ROAS and CAC they imply, per channel and in total.
      *
-     * All figures are in the shop's currency: total_customer_revenue is summed from
-     * customer_stats.sales_all (shop currency) and total_cost is converted to shop currency on import.
+     * Revenue is measured the same way the lifetime figure is - invoice net_amount, excluding
+     * in-process refunds - weighted by each channel's attribution share of the customer, so the
+     * all-time period reproduces traffic_source_stats.total_customer_revenue exactly and every other
+     * period is an honest slice of it. Spend comes from the daily cost rows over the same dates, so
+     * ROAS finally compares like with like: a period's return against that period's spend.
      *
-     * @return array{currency_code: string, totals: array{spend: float, revenue: float, registrations: float, purchases: float, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: float, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
+     * All figures are in the shop's currency.
+     *
+     * @return array{period: string, period_label: string, from: string|null, currency_code: string, totals: array{spend: float, revenue: float, registrations: float, invoices: float, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: float, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
      */
-    public function handle(Shop $shop): array
+    public function handle(Shop $shop, MarketingPeriodEnum $period = MarketingPeriodEnum::LAST_30): array
     {
-        $rows = DB::table('traffic_sources')
-            ->leftJoin('traffic_source_stats', 'traffic_source_stats.traffic_source_id', '=', 'traffic_sources.id')
-            ->where('traffic_sources.shop_id', $shop->id)
-            ->select(
-                'traffic_sources.name',
-                'traffic_sources.type',
-                DB::raw('COALESCE(traffic_source_stats.number_customers, 0) as registrations'),
-                DB::raw('COALESCE(traffic_source_stats.number_customer_purchases, 0) as purchases'),
-                DB::raw('COALESCE(traffic_source_stats.total_customer_revenue, 0) as revenue'),
-                DB::raw('COALESCE(traffic_source_stats.total_cost, 0) as spend'),
-            )
-            ->get();
+        $from = $period->startsAt();
 
-        $spend         = round($rows->sum('spend'), 2);
-        $revenue       = round($rows->sum('revenue'), 2);
+        $sources = DB::table('traffic_sources')
+            ->where('shop_id', $shop->id)
+            ->select('id', 'name', 'type')
+            ->get()
+            ->keyBy('id');
 
-        /* Share-weighted, so kept fractional: truncating per-channel figures to integers would break
-           the guarantee that channels sum to the shop's real totals. */
-        $registrations = round($rows->sum('registrations'), 2);
+        $revenue       = $this->revenueBySource($shop, $from);
+        $registrations = $this->registrationsBySource($shop, $from);
+        $spend         = $this->spendBySource($shop, $from);
 
-        $channels = $rows
-            ->filter(fn ($row) => $row->spend > 0 || $row->revenue > 0 || $row->registrations > 0)
-            ->sortByDesc(fn ($row) => max((float) $row->spend, (float) $row->revenue))
-            ->values()
-            ->map(fn ($row) => [
-                'name'          => $row->name,
-                'type'          => $row->type,
-                'spend'         => round((float) $row->spend, 2),
-                'revenue'       => round((float) $row->revenue, 2),
-                'registrations' => round((float) $row->registrations, 2),
-                'roas'          => $row->spend > 0 ? round($row->revenue / $row->spend, 2) : null,
+        $channels = $sources
+            ->map(fn ($source) => [
+                'name'          => $source->name,
+                'type'          => $source->type,
+                'spend'         => round((float) ($spend[$source->id] ?? 0), 2),
+                'revenue'       => round((float) ($revenue[$source->id]->amount ?? 0), 2),
+                'registrations' => round((float) ($registrations[$source->id] ?? 0), 2),
             ])
+            ->map(fn (array $channel) => $channel + [
+                'roas' => $channel['spend'] > 0 ? round($channel['revenue'] / $channel['spend'], 2) : null,
+            ])
+            ->filter(fn (array $channel) => $channel['spend'] > 0 || $channel['revenue'] > 0 || $channel['registrations'] > 0)
+            ->sortByDesc(fn (array $channel) => max($channel['spend'], $channel['revenue']))
+            ->values()
             ->all();
 
-        $spendByDay = TrafficSourceCost::where('shop_id', $shop->id)
-            ->where('date', '>=', now()->subDays(30)->startOfDay())
+        $totalSpend         = round(array_sum(array_column($channels, 'spend')), 2);
+        $totalRevenue       = round(array_sum(array_column($channels, 'revenue')), 2);
+        $totalRegistrations = round(array_sum(array_column($channels, 'registrations')), 2);
+
+        return [
+            'period'        => $period->value,
+            'period_label'  => MarketingPeriodEnum::labels()[$period->value],
+            'from'          => $from?->toDateString(),
+            'currency_code' => $shop->currency->code,
+            'totals'        => [
+                'spend'         => $totalSpend,
+                'revenue'       => $totalRevenue,
+                'registrations' => $totalRegistrations,
+                'invoices'      => round(collect($revenue)->sum('invoices'), 2),
+                'roas'          => $totalSpend > 0 ? round($totalRevenue / $totalSpend, 2) : null,
+                'cac'           => ($totalSpend > 0 && $totalRegistrations > 0)
+                    ? round($totalSpend / $totalRegistrations, 2)
+                    : null,
+            ],
+            'channels'      => $channels,
+            'spend_by_day'  => $this->spendByDay($shop, $from),
+        ];
+    }
+
+    private function revenueBySource(Shop $shop, ?Carbon $from)
+    {
+        return DB::table('invoices')
+            ->join('model_has_traffic_sources as p', function ($join) {
+                $join->on('p.model_id', '=', 'invoices.customer_id')
+                    ->where('p.model_type', '=', 'Customer');
+            })
+            ->where('invoices.shop_id', $shop->id)
+            ->where('invoices.in_process', false)
+            ->when($from, fn ($query) => $query->where('invoices.date', '>=', $from))
+            ->groupBy('p.traffic_source_id')
+            ->select(
+                'p.traffic_source_id',
+                DB::raw('SUM(invoices.net_amount * p.share) as amount'),
+                DB::raw('SUM(p.share) as invoices'),
+            )
+            ->get()
+            ->keyBy('traffic_source_id');
+    }
+
+    private function registrationsBySource(Shop $shop, ?Carbon $from)
+    {
+        return DB::table('customers')
+            ->join('model_has_traffic_sources as p', function ($join) {
+                $join->on('p.model_id', '=', 'customers.id')
+                    ->where('p.model_type', '=', 'Customer');
+            })
+            ->where('customers.shop_id', $shop->id)
+            ->when($from, fn ($query) => $query->where('customers.created_at', '>=', $from))
+            ->groupBy('p.traffic_source_id')
+            ->select('p.traffic_source_id', DB::raw('SUM(p.share) as registrations'))
+            ->pluck('registrations', 'traffic_source_id');
+    }
+
+    private function spendBySource(Shop $shop, ?Carbon $from)
+    {
+        return DB::table('traffic_source_costs')
+            ->where('shop_id', $shop->id)
+            ->when($from, fn ($query) => $query->where('date', '>=', $from->toDateString()))
+            ->groupBy('traffic_source_id')
+            ->select('traffic_source_id', DB::raw('SUM(amount) as spend'))
+            ->pluck('spend', 'traffic_source_id');
+    }
+
+    /**
+     * @return array<int, array{date: string, amount: float}>
+     */
+    private function spendByDay(Shop $shop, ?Carbon $from): array
+    {
+        /* The sparkline is a shape, not a ledger: it always shows the recent run of days so the tile
+           reads the same whichever period is selected, and never grows unbounded on all time. */
+        $sparklineFrom = $from && $from->isAfter(now()->subDays(30))
+            ? $from
+            : now()->subDays(30)->startOfDay();
+
+        return DB::table('traffic_source_costs')
+            ->where('shop_id', $shop->id)
+            ->where('date', '>=', $sparklineFrom->toDateString())
             ->groupBy('date')
             ->orderBy('date')
             ->select('date', DB::raw('SUM(amount) as amount'))
             ->get()
             ->map(fn ($row) => [
-                'date'   => $row->date->toDateString(),
+                'date'   => Carbon::parse($row->date)->toDateString(),
                 'amount' => round((float) $row->amount, 2),
             ])
             ->all();
-
-        return [
-            'currency_code' => $shop->currency->code,
-            'totals'        => [
-                'spend'         => $spend,
-                'revenue'       => $revenue,
-                'registrations' => $registrations,
-                'purchases'     => round($rows->sum('purchases'), 2),
-                'roas'          => $spend > 0 ? round($revenue / $spend, 2) : null,
-                'cac'           => ($spend > 0 && $registrations > 0) ? round($spend / $registrations, 2) : null,
-            ],
-            'channels'      => $channels,
-            'spend_by_day'  => $spendByDay,
-        ];
     }
 }

--- a/app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php
+++ b/app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php
@@ -13,6 +13,7 @@ use App\Actions\CRM\TrafficSource\GetShopEmailMarketingPerformance;
 use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
 use App\Actions\OrgAction;
 use App\Enums\UI\Marketing\MarketingDashboardTabsEnum;
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
 use App\Models\Catalogue\Shop;
 use App\Models\SysAdmin\Organisation;
 use Inertia\Inertia;
@@ -27,9 +28,14 @@ class ShowMarketingDashboard extends OrgAction
     }
 
 
+    private MarketingPeriodEnum $period = MarketingPeriodEnum::LAST_30;
+
     public function asController(Organisation $organisation, Shop $shop, ActionRequest $request): ActionRequest
     {
         $this->initialisationFromShop($shop, $request)->withTab(MarketingDashboardTabsEnum::values());
+
+        $this->period = MarketingPeriodEnum::tryFrom((string) $request->query('period'))
+            ?? MarketingPeriodEnum::LAST_30;
 
         return $request;
     }
@@ -76,9 +82,13 @@ class ShowMarketingDashboard extends OrgAction
                     'navigation' => MarketingDashboardTabsEnum::navigation()
                 ],
                 'marketing_overview' => array_merge(
-                    GetShopMarketingOverview::run($this->shop),
+                    GetShopMarketingOverview::run($this->shop, $this->period),
                     [
-                        'email'                 => GetShopEmailMarketingPerformance::run($this->shop),
+                        'email'                 => GetShopEmailMarketingPerformance::run($this->shop, $this->period),
+                        'period_options'        => collect(MarketingPeriodEnum::cases())->map(fn ($case) => [
+                            'value' => $case->value,
+                            'label' => MarketingPeriodEnum::labels()[$case->value],
+                        ])->all(),
                         'traffic_sources_route' => [
                             'name'       => 'grp.org.shops.show.marketing.traffic_sources.index',
                             'parameters' => $request->route()->originalParameters()

--- a/app/Enums/UI/Marketing/MarketingPeriodEnum.php
+++ b/app/Enums/UI/Marketing/MarketingPeriodEnum.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Enums\UI\Marketing;
+
+use App\Enums\EnumHelperTrait;
+use Illuminate\Support\Carbon;
+
+enum MarketingPeriodEnum: string
+{
+    use EnumHelperTrait;
+
+    case LAST_7 = 'last_7';
+    case LAST_30 = 'last_30';
+    case LAST_90 = 'last_90';
+    case MONTH_TO_DATE = 'month_to_date';
+    case YEAR_TO_DATE = 'year_to_date';
+    case ALL_TIME = 'all_time';
+
+    public static function labels(): array
+    {
+        return [
+            self::LAST_7->value        => __('Last 7 days'),
+            self::LAST_30->value       => __('Last 30 days'),
+            self::LAST_90->value       => __('Last 90 days'),
+            self::MONTH_TO_DATE->value => __('Month to date'),
+            self::YEAR_TO_DATE->value  => __('Year to date'),
+            self::ALL_TIME->value      => __('All time'),
+        ];
+    }
+
+    /**
+     * The inclusive start of the period, or null for all time. The end is always now: marketing never
+     * asks about the future, and leaving it open keeps today's partial data visible.
+     */
+    public function startsAt(): ?Carbon
+    {
+        return match ($this) {
+            self::LAST_7        => now()->subDays(7)->startOfDay(),
+            self::LAST_30       => now()->subDays(30)->startOfDay(),
+            self::LAST_90       => now()->subDays(90)->startOfDay(),
+            self::MONTH_TO_DATE => now()->startOfMonth(),
+            self::YEAR_TO_DATE  => now()->startOfYear(),
+            self::ALL_TIME      => null,
+        };
+    }
+}

--- a/database/migrations/2026_08_07_100000_create_marketing_daily_view.php
+++ b/database/migrations/2026_08_07_100000_create_marketing_daily_view.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * A view cannot take a date range as an argument, so the existing marketing_channel_performance
+     * can only ever answer all-time questions. This one is at (shop, channel, day) grain instead:
+     * management filters on `date` and aggregates whatever window they actually care about.
+     *
+     * Revenue is share-weighted invoice net, matching the dashboard exactly, so a SUM over all days
+     * reproduces marketing_channel_performance and any sub-window is an honest slice of it.
+     */
+    public function up(): void
+    {
+        DB::statement("
+            CREATE OR REPLACE VIEW marketing_channel_daily AS
+            WITH spend AS (
+                SELECT shop_id, traffic_source_id, date::date AS date, SUM(amount) AS cost
+                FROM traffic_source_costs
+                GROUP BY 1, 2, 3
+            ),
+            revenue AS (
+                SELECT i.shop_id,
+                       p.traffic_source_id,
+                       i.date::date                        AS date,
+                       SUM(i.net_amount * p.share)         AS revenue,
+                       SUM(p.share)                        AS invoices
+                FROM invoices i
+                JOIN model_has_traffic_sources p
+                  ON p.model_id = i.customer_id AND p.model_type = 'Customer'
+                WHERE i.in_process = false AND i.date IS NOT NULL
+                GROUP BY 1, 2, 3
+            ),
+            registrations AS (
+                SELECT c.shop_id,
+                       p.traffic_source_id,
+                       c.created_at::date                  AS date,
+                       SUM(p.share)                        AS registrations
+                FROM customers c
+                JOIN model_has_traffic_sources p
+                  ON p.model_id = c.id AND p.model_type = 'Customer'
+                GROUP BY 1, 2, 3
+            ),
+            grid AS (
+                SELECT shop_id, traffic_source_id, date FROM spend
+                UNION SELECT shop_id, traffic_source_id, date FROM revenue
+                UNION SELECT shop_id, traffic_source_id, date FROM registrations
+            )
+            SELECT
+                g.date,
+                g.shop_id,
+                s.slug                                     AS shop,
+                ts.name                                    AS channel,
+                ts.type,
+                COALESCE(sp.cost, 0)                       AS cost,
+                COALESCE(rv.revenue, 0)                    AS revenue,
+                COALESCE(rv.invoices, 0)                   AS invoices,
+                COALESCE(rg.registrations, 0)              AS registrations
+            FROM grid g
+            JOIN shops s ON s.id = g.shop_id
+            JOIN traffic_sources ts ON ts.id = g.traffic_source_id
+            LEFT JOIN spend sp
+                   ON sp.shop_id = g.shop_id AND sp.traffic_source_id = g.traffic_source_id AND sp.date = g.date
+            LEFT JOIN revenue rv
+                   ON rv.shop_id = g.shop_id AND rv.traffic_source_id = g.traffic_source_id AND rv.date = g.date
+            LEFT JOIN registrations rg
+                   ON rg.shop_id = g.shop_id AND rg.traffic_source_id = g.traffic_source_id AND rg.date = g.date
+        ");
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS marketing_channel_daily');
+    }
+};

--- a/resources/js/Components/DataDisplay/MarketingOverview.vue
+++ b/resources/js/Components/DataDisplay/MarketingOverview.vue
@@ -11,6 +11,7 @@ import { useLocaleStore } from '@/Stores/locale'
 import { routeType } from '@/types/route'
 import { route } from 'ziggy-js'
 import { trans } from 'laravel-vue-i18n'
+import { router } from '@inertiajs/vue3'
 
 const props = defineProps<{
     overview: {
@@ -19,7 +20,7 @@ const props = defineProps<{
             spend: number
             revenue: number
             registrations: number
-            purchases: number
+            invoices: number
             roas: number | null
             cac: number | null
         }
@@ -31,6 +32,10 @@ const props = defineProps<{
             registrations: number
             roas: number | null
         }[]
+        period: string
+        period_label: string
+        from: string | null
+        period_options: { value: string, label: string }[]
         spend_by_day: { date: string, amount: number }[]
         email: {
             totals: {
@@ -94,6 +99,13 @@ const sparkline = computed(() => {
 
 const roasIsGood = computed(() => (props.overview.totals.roas ?? 0) >= 1)
 
+/* Period lives in the URL so a filtered view can be shared, bookmarked and reloaded. */
+const selectPeriod = (period: string) => router.get(
+    window.location.pathname,
+    { period },
+    { preserveScroll: true, preserveState: true, replace: true }
+)
+
 const pct = (part: number, whole: number) => whole > 0 ? `${((part / whole) * 100).toFixed(1)}%` : '—'
 
 /* Registrations are share-weighted, so a channel can legitimately hold 12.5 of them. */
@@ -108,6 +120,22 @@ const typeLabel: Record<string, string> = {
 
 <template>
     <div class="px-4 py-5 md:px-6 space-y-6">
+
+        <!-- Period filter: one row above everything it governs -->
+        <div class="flex flex-wrap items-center gap-1">
+            <button v-for="option in overview.period_options" :key="option.value"
+                type="button"
+                class="px-2.5 py-1 text-xs rounded-md border transition-colors"
+                :class="option.value === overview.period
+                    ? 'bg-gray-800 text-white border-gray-800'
+                    : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'"
+                @click="selectPeriod(option.value)">
+                {{ option.label }}
+            </button>
+            <span v-if="overview.from" class="ml-2 text-xs text-gray-400">
+                {{ trans('since') }} {{ overview.from }}
+            </span>
+        </div>
 
         <!-- KPI row: ROAS is the hero, everything else supports it -->
         <div class="grid grid-cols-2 lg:grid-cols-3 gap-px rounded-xl overflow-hidden bg-gray-200 ring-1 ring-gray-200">
@@ -140,7 +168,7 @@ const typeLabel: Record<string, string> = {
                             stroke="#ffffff" stroke-width="2" />
                     </svg>
                 </div>
-                <div v-if="sparkline" class="mt-0.5 text-xs text-gray-400">{{ trans('last 30 days') }}</div>
+                <div v-if="sparkline" class="mt-0.5 text-xs text-gray-400">{{ trans('daily, recent') }}</div>
             </div>
 
             <div class="bg-white p-5">
@@ -159,7 +187,7 @@ const typeLabel: Record<string, string> = {
                 <div class="text-xs text-gray-500">{{ trans('Attributed customers') }}</div>
                 <div class="mt-1 text-2xl font-medium text-gray-800">
                     {{ fmtShare(overview.totals.registrations) }}
-                    <span class="text-sm text-gray-400">· {{ fmtShare(overview.totals.purchases) }} {{ trans('orders') }}</span>
+                    <span class="text-sm text-gray-400">· {{ fmtShare(overview.totals.invoices) }} {{ trans('invoices') }}</span>
                 </div>
             </div>
         </div>
@@ -169,7 +197,7 @@ const typeLabel: Record<string, string> = {
             <div class="flex items-center justify-between">
                 <div>
                     <span class="text-sm font-medium text-gray-800">{{ trans('Channel performance') }}</span>
-                    <span class="ml-2 text-xs text-gray-400">{{ trans('all time, shop currency') }}</span>
+                    <span class="ml-2 text-xs text-gray-400">{{ overview.period_label.toLowerCase() }}, {{ overview.currency_code }}</span>
                 </div>
                 <div class="flex items-center gap-4 text-xs text-gray-500">
                     <span class="flex items-center gap-1.5">
@@ -235,7 +263,7 @@ const typeLabel: Record<string, string> = {
             <div class="flex items-center justify-between">
                 <div>
                     <span class="text-sm font-medium text-gray-800">{{ trans('Email marketing') }}</span>
-                    <span class="ml-2 text-xs text-gray-400">{{ trans('recent mailshots · cost estimated from SES') }}</span>
+                    <span class="ml-2 text-xs text-gray-400">{{ trans('sent') }} {{ overview.period_label.toLowerCase() }} · {{ trans('cost estimated from SES') }}</span>
                 </div>
                 <Link :href="route(overview.mailshots_route.name, overview.mailshots_route.parameters)"
                     class="text-xs text-gray-500 hover:text-gray-800">{{ trans('All mailshots') }} →</Link>

--- a/tests/Feature/CRM/MarketingPeriodTest.php
+++ b/tests/Feature/CRM/MarketingPeriodTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
+use App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution;
+use App\Actions\CRM\TrafficSource\StoreTrafficSourceCost;
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
+use App\Models\CRM\TrafficSourceCost;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->googleAds = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+    $this->customer  = createCustomer($this->shop);
+
+    $this->customer->trafficSources()->detach();
+    $this->customer->update(['traffic_sources' => '1700000000b']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    TrafficSourceCost::where('shop_id', $this->shop->id)->delete();
+    DB::table('invoices')->where('customer_id', $this->customer->id)->delete();
+});
+
+function invoiceOn(string $date, float $net, $customer, $shop, bool $inProcess = false): void
+{
+    DB::table('invoices')->insert([
+        'group_id'        => $shop->group_id,
+        'organisation_id' => $shop->organisation_id,
+        'shop_id'         => $shop->id,
+        'customer_id'     => $customer->id,
+        'currency_id'     => $shop->currency_id,
+        'tax_category_id' => $shop->taxCategory?->id ?? App\Models\Helpers\TaxCategory::firstOrFail()->id,
+        'reference'       => 'INV-'.uniqid(),
+        'slug'            => 'inv-'.uniqid(),
+        'type'            => 'invoice',
+        'net_amount'      => $net,
+        'total_amount'    => $net,
+        'in_process'      => $inProcess,
+        'payment_data'    => '{}',
+        'data'            => '{}',
+        'date'            => $date,
+        'created_at'      => $date,
+        'updated_at'      => $date,
+    ]);
+}
+
+it('counts only revenue and spend inside the selected period', function () {
+    invoiceOn(now()->subDays(3)->toDateTimeString(), 400, $this->customer, $this->shop);
+    invoiceOn(now()->subDays(60)->toDateTimeString(), 1000, $this->customer, $this->shop);
+
+    StoreTrafficSourceCost::run($this->googleAds, [
+        'date'               => now()->subDays(3)->toDateString(),
+        'source_amount'      => 100,
+        'source_currency_id' => $this->shop->currency_id,
+    ]);
+    StoreTrafficSourceCost::run($this->googleAds, [
+        'date'               => now()->subDays(60)->toDateString(),
+        'source_amount'      => 500,
+        'source_currency_id' => $this->shop->currency_id,
+    ]);
+
+    $recent = GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::LAST_7);
+
+    expect($recent['totals']['revenue'])->toBe(400.0);
+    expect($recent['totals']['spend'])->toBe(100.0);
+    expect($recent['totals']['roas'])->toBe(4.0);
+
+    $allTime = GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::ALL_TIME);
+
+    expect($allTime['totals']['revenue'])->toBe(1400.0);
+    expect($allTime['totals']['spend'])->toBe(600.0);
+});
+
+it('reproduces the lifetime stats figure when the period is all time', function () {
+    invoiceOn(now()->subDays(200)->toDateTimeString(), 250, $this->customer, $this->shop);
+    invoiceOn(now()->subDay()->toDateTimeString(), 750, $this->customer, $this->shop);
+
+    // sales_all is maintained by its own hydrator; bring it in sync before comparing the two paths.
+    App\Actions\CRM\Customer\Hydrators\CustomerHydrateInvoices::run($this->customer->id);
+    TrafficSourceHydrateCustomers::run($this->googleAds);
+
+    $allTime = GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::ALL_TIME);
+
+    expect($allTime['totals']['revenue'])
+        ->toBe(round((float) $this->googleAds->stats()->first()->total_customer_revenue, 2));
+});
+
+it('splits period revenue between channels by their shares', function () {
+    $organic = createTrafficSource($this->shop, 'organic-google', 'Organic Google');
+
+    $this->customer->update(['traffic_sources' => '1700000000b|1700000100a']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    invoiceOn(now()->subDay()->toDateTimeString(), 1000, $this->customer, $this->shop);
+
+    $overview = GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::LAST_7);
+    $channels = collect($overview['channels'])->keyBy('type');
+
+    expect($channels['google-ads']['revenue'])->toBe(500.0);
+    expect($channels['organic-google']['revenue'])->toBe(500.0);
+    expect($overview['totals']['revenue'])->toBe(1000.0);
+});
+
+it('excludes in-process refund invoices', function () {
+    invoiceOn(now()->subDay()->toDateTimeString(), 500, $this->customer, $this->shop);
+    invoiceOn(now()->subDay()->toDateTimeString(), 9999, $this->customer, $this->shop, inProcess: true);
+
+    expect(GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::LAST_7)['totals']['revenue'])
+        ->toBe(500.0);
+});
+
+it('reports the selected period back to the dashboard', function () {
+    $overview = GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::MONTH_TO_DATE);
+
+    expect($overview['period'])->toBe('month_to_date');
+    expect($overview['from'])->toBe(now()->startOfMonth()->toDateString());
+
+    expect(GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::ALL_TIME)['from'])->toBeNull();
+});
+
+it('serves the same period numbers through the daily sql view', function () {
+    invoiceOn(now()->subDays(3)->toDateTimeString(), 400, $this->customer, $this->shop);
+    StoreTrafficSourceCost::run($this->googleAds, [
+        'date'               => now()->subDays(3)->toDateString(),
+        'source_amount'      => 100,
+        'source_currency_id' => $this->shop->currency_id,
+    ]);
+
+    $row = collect(DB::select(
+        'SELECT SUM(revenue) AS revenue, SUM(cost) AS cost
+         FROM marketing_channel_daily
+         WHERE shop_id = ? AND date >= ?',
+        [$this->shop->id, now()->subDays(7)->toDateString()]
+    ))->first();
+
+    expect(round((float) $row->revenue, 2))->toBe(400.0);
+    expect(round((float) $row->cost, 2))->toBe(100.0);
+});

--- a/tests/Feature/CRM/TrafficSourceCostTest.php
+++ b/tests/Feature/CRM/TrafficSourceCostTest.php
@@ -163,44 +163,32 @@ it('exposes cost, roas and cac on the shop traffic sources listing', function ()
     expect((float) $row->cac)->toBe(12.5);
 });
 
-it('assembles the marketing overview from the stats rollups', function () {
+it('aggregates period spend per channel into the marketing overview', function () {
     $organic = createTrafficSource($this->shop, 'organic-google', 'Organic Google');
-    $organic->stats()->updateOrCreate(
-        ['traffic_source_id' => $organic->id],
-        ['number_customers' => 10, 'total_customer_revenue' => 300.00, 'total_cost' => 0]
-    );
 
-    StoreTrafficSourceCost::run($this->trafficSource, [
-        'date'               => now()->subDays(2)->toDateString(),
-        'source_amount'      => 100.00,
-        'source_currency_id' => $this->currency->id,
-    ]);
-    StoreTrafficSourceCost::run($this->trafficSource, [
-        'date'               => now()->subDay()->toDateString(),
-        'source_amount'      => 100.00,
-        'source_currency_id' => $this->currency->id,
-    ]);
+    foreach ([2, 1] as $daysAgo) {
+        StoreTrafficSourceCost::run($this->trafficSource, [
+            'date'               => now()->subDays($daysAgo)->toDateString(),
+            'source_amount'      => 100.00,
+            'source_currency_id' => $this->currency->id,
+        ]);
+    }
     TrafficSourceHydrateCosts::run($this->trafficSource);
-    $this->trafficSource->stats()->update([
-        'number_customers'       => 4,
-        'total_customer_revenue' => 500.00,
-    ]);
 
-    $overview = GetShopMarketingOverview::run($this->shop);
+    // A channel with attributed customers but no spend still has to appear, with no ROAS to show.
+    $customer = createCustomer($this->shop);
+    $customer->trafficSources()->detach();
+    $customer->update(['traffic_sources' => '1700000000a']);
+    App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution::run($customer->fresh());
+
+    $overview = GetShopMarketingOverview::run($this->shop, App\Enums\UI\Marketing\MarketingPeriodEnum::ALL_TIME);
+    $channels = collect($overview['channels'])->keyBy('type');
 
     expect($overview['totals']['spend'])->toBe(200.0);
-    expect($overview['totals']['revenue'])->toBe(800.0);
-    expect($overview['totals']['roas'])->toBe(4.0);
-    expect($overview['totals']['cac'])->toBe(round(200 / 14, 2));
     expect($overview['currency_code'])->toBe($this->currency->code);
-
-    expect($overview['channels'])->toHaveCount(2);
-    expect($overview['channels'][0]['type'])->toBe('google-ads');
-    expect($overview['channels'][0]['roas'])->toBe(2.5);
-    expect($overview['channels'][1]['roas'])->toBeNull();
-
-    expect($overview['spend_by_day'])->toHaveCount(2);
-    expect($overview['spend_by_day'][0]['amount'])->toBe(100.0);
+    expect((float) $channels['google-ads']['spend'])->toBe(200.0);
+    expect($channels['organic-google']['roas'])->toBeNull();
+    expect($channels['organic-google']['registrations'])->toBe(1.0);
 });
 
 it('reports a null roas and cac in the overview when nothing was spent', function () {


### PR DESCRIPTION
Closes the biggest correctness caveat both hostile reviews flagged: ROAS was **all-time** — lifetime revenue over whatever spend happened to be imported — so it drifted upward by construction and could not answer *"how did July do?"*.

## Why this wasn't just a UI filter

`traffic_source_stats.total_customer_revenue` is **lifetime** revenue per customer. There is no date to slice it by. Period revenue had to be rebuilt from a dated grain.

I used **invoices**, because that is exactly what `sales_all` is built from (`invoices.net_amount` where `in_process = false`), weighted by each channel's attribution share.

That buys an invariant worth keeping:

> **The all-time period reproduces the lifetime figure exactly.**

Same measure, same weighting — so every shorter period is an honest slice of the number already shown on the traffic sources listing, not a second opinion computed a different way. `it('reproduces the lifetime stats figure when the period is all time')` asserts it directly.

ROAS now compares like with like: a period's revenue against **that period's** spend.

## What's included

- **`MarketingPeriodEnum`** — last 7 / 30 / 90 days, month to date, year to date, all time. Defaults to 30 days.
- **Revenue, registrations and spend** all filter to the selected window.
- **Email panel** filters by *send* date — the question there is whether the mailshots sent in a period paid for themselves.
- **Filter row** above the dashboard; period lives in the URL so a filtered view survives reload and can be shared. Every panel header names its own period, so no figure is unlabelled.
- **`marketing_channel_daily` view** at (shop, channel, day) grain. A view can't take a date argument, so `marketing_channel_performance` can only ever answer all-time questions — management filters `date` on this one and aggregates their own window. Summing it whole reproduces the all-time view.

## Sparkline

Always shows the recent run of days regardless of selected period — it's a shape, not a ledger, so the tile reads consistently and never grows unbounded on "all time".

## Test change worth flagging

`it('assembles the marketing overview from the stats rollups')` asserted the **old** semantics (revenue read from stats rollups). Rewritten as `it('aggregates period spend per channel into the marketing overview')` — covering period spend aggregation and the no-spend channel case. Revenue correctness moved to `MarketingPeriodTest`, where it's tested against real invoices rather than hand-set rollup values.

## Tests

`tests/Feature/CRM/MarketingPeriodTest.php` — 6 tests: period windowing, the all-time/lifetime equality, share splitting within a period, in-process refund exclusion, period metadata, and the daily SQL view returning the same numbers.

All green: 6 period + 9 cost + 10 email.

## Not included

Customer journey timeline, data-quality dashboard, platform-native CSV parsers, campaign-level stats hydrator (Phase 7), Phase 8 docs.