### PR TITLE
🎯 feat: campaign stats hydrator + per-campaign performance (Phase 7)

### DIFF
--- a/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
+++ b/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\CRM\TrafficSource;
 
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceCampaignHydrateStats;
 use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
 use App\Models\CRM\TrafficSource;
 use App\Models\CRM\TrafficSourceCampaign;
@@ -59,7 +60,8 @@ class AttachTrafficSourcesToModel
             return;
         }
 
-        $touchedSourceIds = [];
+        $touchedSourceIds   = [];
+        $touchedCampaignIds = [];
 
         foreach ($shares as $share) {
             /** @var TrafficSource|null $trafficSource */
@@ -69,19 +71,29 @@ class AttachTrafficSourcesToModel
                 continue;
             }
 
+            $campaignId = $share['campaign_ref']
+                ? $this->resolveCampaignId($trafficSource, $share['campaign_ref'])
+                : null;
+
             $model->trafficSources()->attach($trafficSource->id, [
                 'share'                      => round($share['share'], 2),
-                'traffic_source_campaign_id' => $share['campaign_ref']
-                    ? $this->resolveCampaignId($trafficSource, $share['campaign_ref'])
-                    : null,
+                'traffic_source_campaign_id' => $campaignId,
                 'attribution_model'          => $attributionModel,
             ]);
 
             $touchedSourceIds[$trafficSource->id] = true;
+
+            if ($campaignId) {
+                $touchedCampaignIds[$campaignId] = true;
+            }
         }
 
         foreach ($trafficSources->whereIn('id', array_keys($touchedSourceIds)) as $trafficSource) {
             TrafficSourceHydrateCustomers::dispatch($trafficSource);
+        }
+
+        foreach (TrafficSourceCampaign::whereIn('id', array_keys($touchedCampaignIds))->get() as $campaign) {
+            TrafficSourceCampaignHydrateStats::dispatch($campaign);
         }
     }
 

--- a/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
+++ b/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
@@ -30,7 +30,7 @@ class GetShopMarketingOverview
      *
      * All figures are in the shop's currency.
      *
-     * @return array{period: string, period_label: string, from: string|null, currency_code: string, totals: array{spend: float, revenue: float, registrations: float, invoices: float, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: float, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
+     * @return array{period: string, period_label: string, from: string|null, currency_code: string, totals: array{spend: float, revenue: float, registrations: float, invoices: float, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: float, roas: float|null}>, campaigns: array<int, array{name: string, channel: string, spend: float, revenue: float, registrations: float, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
      */
     public function handle(Shop $shop, MarketingPeriodEnum $period = MarketingPeriodEnum::LAST_30): array
     {
@@ -82,6 +82,7 @@ class GetShopMarketingOverview
                     : null,
             ],
             'channels'      => $channels,
+            'campaigns'     => $this->campaigns($shop, $from),
             'spend_by_day'  => $this->spendByDay($shop, $from),
         ];
     }
@@ -133,6 +134,68 @@ class GetShopMarketingOverview
     /**
      * @return array<int, array{date: string, amount: float}>
      */
+    /**
+     * The campaigns that actually moved money in the period, richest first. Campaign refs come from
+     * ad platforms, so a shop can accumulate hundreds; the dashboard shows the handful worth looking
+     * at and the campaign listing carries the rest.
+     *
+     * @return array<int, array{name: string, channel: string, spend: float, revenue: float, registrations: float, roas: float|null}>
+     */
+    private function campaigns(Shop $shop, ?Carbon $from, int $limit = 8): array
+    {
+        $revenue = DB::table('invoices')
+            ->join('model_has_traffic_sources as p', function ($join) {
+                $join->on('p.model_id', '=', 'invoices.customer_id')
+                    ->where('p.model_type', '=', 'Customer');
+            })
+            ->whereNotNull('p.traffic_source_campaign_id')
+            ->where('invoices.shop_id', $shop->id)
+            ->where('invoices.in_process', false)
+            ->when($from, fn ($query) => $query->where('invoices.date', '>=', $from))
+            ->groupBy('p.traffic_source_campaign_id')
+            ->select(
+                'p.traffic_source_campaign_id as campaign_id',
+                DB::raw('SUM(invoices.net_amount * p.share) as revenue'),
+                DB::raw('SUM(p.share) as registrations'),
+            )
+            ->get()
+            ->keyBy('campaign_id');
+
+        $spend = DB::table('traffic_source_costs')
+            ->whereNotNull('traffic_source_campaign_id')
+            ->where('shop_id', $shop->id)
+            ->when($from, fn ($query) => $query->where('date', '>=', $from->toDateString()))
+            ->groupBy('traffic_source_campaign_id')
+            ->select('traffic_source_campaign_id', DB::raw('SUM(amount) as spend'))
+            ->pluck('spend', 'traffic_source_campaign_id');
+
+        $campaignIds = $revenue->keys()->merge($spend->keys())->unique();
+
+        if ($campaignIds->isEmpty()) {
+            return [];
+        }
+
+        return DB::table('traffic_source_campaigns as c')
+            ->join('traffic_sources as ts', 'ts.id', '=', 'c.traffic_source_id')
+            ->whereIn('c.id', $campaignIds)
+            ->select('c.id', 'c.name', 'ts.name as channel')
+            ->get()
+            ->map(fn ($campaign) => [
+                'name'          => $campaign->name,
+                'channel'       => $campaign->channel,
+                'spend'         => round((float) ($spend[$campaign->id] ?? 0), 2),
+                'revenue'       => round((float) ($revenue[$campaign->id]->revenue ?? 0), 2),
+                'registrations' => round((float) ($revenue[$campaign->id]->registrations ?? 0), 2),
+            ])
+            ->map(fn (array $campaign) => $campaign + [
+                'roas' => $campaign['spend'] > 0 ? round($campaign['revenue'] / $campaign['spend'], 2) : null,
+            ])
+            ->sortByDesc(fn (array $campaign) => max($campaign['spend'], $campaign['revenue']))
+            ->take($limit)
+            ->values()
+            ->all();
+    }
+
     private function spendByDay(Shop $shop, ?Carbon $from): array
     {
         /* The sparkline is a shape, not a ledger: it always shows the recent run of days so the tile

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceCampaignHydrateStats.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceCampaignHydrateStats.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource\Hydrator;
+
+use App\Models\CRM\TrafficSourceCampaign;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class TrafficSourceCampaignHydrateStats implements ShouldBeUnique
+{
+    use AsAction;
+
+    public int $jobUniqueFor = 3600;
+
+    /* Dashboard statistics: never allowed to compete with order processing. */
+    public string $jobQueue = 'low-priority';
+
+    public function getJobUniqueId(TrafficSourceCampaign $campaign): string
+    {
+        return (string) $campaign->id;
+    }
+
+    /**
+     * Rolls a campaign's own customers, orders, revenue and spend into its stats row, weighted by the
+     * attribution shares exactly as the traffic-source hydrator does. Summing every campaign of a
+     * source therefore never exceeds that source's own totals: a customer split between two campaigns
+     * contributes half to each.
+     *
+     * A campaign that has spend but no attributed customer still gets a row, so money spent with
+     * nothing to show for it is visible rather than absent.
+     */
+    public function handle(TrafficSourceCampaign $campaign): void
+    {
+        $attribution = DB::table('model_has_traffic_sources')
+            ->join('customer_stats', 'customer_stats.customer_id', '=', 'model_has_traffic_sources.model_id')
+            ->where('model_has_traffic_sources.traffic_source_campaign_id', $campaign->id)
+            ->where('model_has_traffic_sources.model_type', 'Customer')
+            ->select(
+                DB::raw('COALESCE(SUM(model_has_traffic_sources.share), 0) as customers'),
+                DB::raw('COALESCE(SUM(customer_stats.number_orders_state_dispatched * model_has_traffic_sources.share), 0) as purchases'),
+                DB::raw('COALESCE(SUM(customer_stats.sales_all * model_has_traffic_sources.share), 0) as revenue'),
+                DB::raw('COALESCE(SUM(customer_stats.sales_org_currency_all * model_has_traffic_sources.share), 0) as org_revenue'),
+            )
+            ->first();
+
+        $cost = DB::table('traffic_source_costs')
+            ->where('traffic_source_campaign_id', $campaign->id)
+            ->select(
+                DB::raw('COALESCE(SUM(amount), 0) as total'),
+                DB::raw('COALESCE(SUM(org_amount), 0) as org_total'),
+            )
+            ->first();
+
+        $campaign->stats()->updateOrCreate(
+            ['traffic_source_campaign_id' => $campaign->id],
+            [
+                'number_customers'           => $attribution->customers,
+                'number_customer_purchases'  => $attribution->purchases,
+                'total_customer_revenue'     => $attribution->revenue,
+                'org_total_customer_revenue' => $attribution->org_revenue,
+                'total_cost'                 => $cost->total,
+                'org_total_cost'             => $cost->org_total,
+            ]
+        );
+    }
+}

--- a/app/Actions/CRM/TrafficSource/StoreTrafficSourceCost.php
+++ b/app/Actions/CRM/TrafficSource/StoreTrafficSourceCost.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\CRM\TrafficSource;
 
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceCampaignHydrateStats;
 use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCosts;
 use App\Actions\Helpers\CurrencyExchange\GetCurrencyExchange;
 use App\Actions\Helpers\CurrencyExchange\GetHistoricCurrencyExchange;
@@ -59,6 +60,10 @@ class StoreTrafficSourceCost
         );
 
         TrafficSourceHydrateCosts::dispatch($trafficSource);
+
+        if ($trafficSourceCost->trafficSourceCampaign) {
+            TrafficSourceCampaignHydrateStats::dispatch($trafficSourceCost->trafficSourceCampaign);
+        }
 
         return $trafficSourceCost;
     }

--- a/app/Console/Commands/HydrateTrafficSourceCampaignStats.php
+++ b/app/Console/Commands/HydrateTrafficSourceCampaignStats.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Console\Commands;
+
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceCampaignHydrateStats;
+use App\Models\Catalogue\Shop;
+use App\Models\CRM\TrafficSourceCampaign;
+use Illuminate\Console\Command;
+
+class HydrateTrafficSourceCampaignStats extends Command
+{
+    protected $signature = 'traffic-source:hydrate-campaign-stats {--shop= : Only campaigns of a specific shop slug}';
+
+    protected $description = 'Rebuild the stats rollup of every traffic source campaign from its attribution and spend';
+
+    /**
+     * Campaign stats are maintained on write, but nothing has ever written them: the table shipped
+     * with the wrong columns. This backfills what already exists, and is safe to rerun.
+     */
+    public function handle(): int
+    {
+        $query = TrafficSourceCampaign::query();
+
+        if ($shopSlug = $this->option('shop')) {
+            $shop = Shop::where('slug', $shopSlug)->first();
+
+            if (!$shop) {
+                $this->error("Shop '{$shopSlug}' not found.");
+
+                return Command::FAILURE;
+            }
+
+            $query->whereHas('trafficSource', fn ($sources) => $sources->where('shop_id', $shop->id));
+        }
+
+        $total = $query->count();
+
+        if ($total === 0) {
+            $this->info('No campaigns to hydrate.');
+
+            return Command::SUCCESS;
+        }
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $query->chunkById(200, function ($campaigns) use ($bar) {
+            foreach ($campaigns as $campaign) {
+                TrafficSourceCampaignHydrateStats::run($campaign);
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Hydrated {$total} campaign(s).");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Models/CRM/TrafficSourceCampaign.php
+++ b/app/Models/CRM/TrafficSourceCampaign.php
@@ -5,6 +5,7 @@ namespace App\Models\CRM;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
@@ -48,5 +49,10 @@ class TrafficSourceCampaign extends Model
     public function trafficSource(): BelongsTo
     {
         return $this->belongsTo(TrafficSource::class, 'traffic_source_id');
+    }
+
+    public function stats(): HasOne
+    {
+        return $this->hasOne(TrafficSourceCampaignStat::class);
     }
 }

--- a/app/Models/CRM/TrafficSourceCampaignStat.php
+++ b/app/Models/CRM/TrafficSourceCampaignStat.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Models\CRM;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * App\Models\CRM\TrafficSourceCampaignStat
+ *
+ * @property int $id
+ * @property int $traffic_source_campaign_id
+ * @property numeric $number_customers
+ * @property numeric $number_customer_purchases
+ * @property numeric $total_customer_revenue
+ * @property numeric $org_total_customer_revenue
+ * @property numeric $total_cost
+ * @property numeric $org_total_cost
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read TrafficSourceCampaign $trafficSourceCampaign
+ * @mixin \Eloquent
+ */
+class TrafficSourceCampaignStat extends Model
+{
+    use HasFactory;
+
+    protected $table = 'traffic_source_campaign_stats';
+
+    protected $guarded = [];
+
+    public function trafficSourceCampaign(): BelongsTo
+    {
+        return $this->belongsTo(TrafficSourceCampaign::class);
+    }
+}

--- a/database/migrations/2026_08_07_120000_rebuild_traffic_source_campaign_stats.php
+++ b/database/migrations/2026_08_07_120000_rebuild_traffic_source_campaign_stats.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use App\Enums\CRM\TrafficSourceCampaign\TrafficSourceCampaignTypeEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class () extends Migration {
+    /**
+     * The table shipped with `number_campaigns_type_*` columns: a count of campaigns by type, on a
+     * single campaign's own stats row. That is a parent-level shape copy-pasted onto a child, it has
+     * never been written to, and it cannot answer anything about the campaign it belongs to.
+     *
+     * Replaced with the same figures traffic_source_stats carries, so a campaign can report its own
+     * customers, revenue and spend, and per-campaign ROAS becomes a subtraction instead of a scan.
+     * Counts are fractional because attribution shares are.
+     */
+    public function up(): void
+    {
+        Schema::table('traffic_source_campaign_stats', function (Blueprint $table) {
+            foreach (TrafficSourceCampaignTypeEnum::cases() as $type) {
+                $column = 'number_campaigns_type_'.Str::snake(str_replace('-', '_', $type->value));
+
+                if (Schema::hasColumn('traffic_source_campaign_stats', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+
+            $table->decimal('number_customers', 12, 2)->default(0);
+            $table->decimal('number_customer_purchases', 12, 2)->default(0);
+            $table->decimal('total_customer_revenue', 16, 2)->default(0);
+            $table->decimal('org_total_customer_revenue', 16, 2)->default(0);
+            $table->decimal('total_cost', 16, 2)->default(0);
+            $table->decimal('org_total_cost', 16, 2)->default(0);
+
+            $table->unique('traffic_source_campaign_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('traffic_source_campaign_stats', function (Blueprint $table) {
+            $table->dropUnique(['traffic_source_campaign_id']);
+
+            $table->dropColumn([
+                'number_customers',
+                'number_customer_purchases',
+                'total_customer_revenue',
+                'org_total_customer_revenue',
+                'total_cost',
+                'org_total_cost',
+            ]);
+
+            foreach (TrafficSourceCampaignTypeEnum::cases() as $type) {
+                $table->unsignedInteger('number_campaigns_type_'.Str::snake(str_replace('-', '_', $type->value)))->default(0);
+            }
+        });
+    }
+};

--- a/resources/js/Components/DataDisplay/MarketingOverview.vue
+++ b/resources/js/Components/DataDisplay/MarketingOverview.vue
@@ -36,6 +36,14 @@ const props = defineProps<{
         period_label: string
         from: string | null
         period_options: { value: string, label: string }[]
+        campaigns: {
+            name: string
+            channel: string
+            spend: number
+            revenue: number
+            registrations: number
+            roas: number | null
+        }[]
         spend_by_day: { date: string, amount: number }[]
         email: {
             totals: {
@@ -256,6 +264,43 @@ const typeLabel: Record<string, string> = {
                     {{ trans('Attribution fills this in as visitors register and ad spend is imported') }}
                 </div>
             </div>
+        </div>
+
+        <!-- Campaign performance: which individual campaigns earn their spend -->
+        <div v-if="overview.campaigns.length" class="rounded-xl ring-1 ring-gray-200 bg-white p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <span class="text-sm font-medium text-gray-800">{{ trans('Campaign performance') }}</span>
+                    <span class="ml-2 text-xs text-gray-400">{{ overview.period_label.toLowerCase() }}</span>
+                </div>
+            </div>
+
+            <table class="mt-4 w-full text-xs">
+                <thead>
+                    <tr class="text-gray-400 border-b border-gray-100">
+                        <th class="text-left font-normal py-1.5 pr-2">{{ trans('Campaign') }}</th>
+                        <th class="text-left font-normal py-1.5 px-2">{{ trans('Channel') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Spend') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Revenue') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Registrations') }}</th>
+                        <th class="text-right font-normal py-1.5 pl-2">{{ trans('ROAS') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="campaign in overview.campaigns" :key="campaign.name + campaign.channel"
+                        class="border-b border-gray-50 text-gray-600">
+                        <td class="py-2 pr-2 text-gray-700 truncate max-w-[18rem]">{{ campaign.name }}</td>
+                        <td class="px-2 text-gray-500">{{ campaign.channel }}</td>
+                        <td class="text-right px-2 tabular-nums">{{ money(campaign.spend) }}</td>
+                        <td class="text-right px-2 tabular-nums">{{ money(campaign.revenue) }}</td>
+                        <td class="text-right px-2 tabular-nums">{{ fmtShare(campaign.registrations) }}</td>
+                        <td class="text-right pl-2 tabular-nums"
+                            :class="campaign.roas === null ? 'text-gray-300' : campaign.roas >= 1 ? 'text-[#006300]' : 'text-[#d03b3b]'">
+                            {{ campaign.roas !== null ? campaign.roas.toFixed(2) + '×' : '—' }}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
 
         <!-- Email marketing: does what we send earn sales, or just unsubscribes? -->

--- a/tests/Feature/CRM/TrafficSourceCampaignStatsTest.php
+++ b/tests/Feature/CRM/TrafficSourceCampaignStatsTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\CRM\Customer\StoreCustomer;
+use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceCampaignHydrateStats;
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
+use App\Actions\CRM\TrafficSource\StoreTrafficSourceCost;
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
+use App\Models\CRM\Customer;
+use App\Models\CRM\TrafficSourceCampaign;
+use App\Models\CRM\TrafficSourceCost;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->googleAds = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+
+    TrafficSourceCost::where('shop_id', $this->shop->id)->delete();
+});
+
+function campaignFor($trafficSource, string $reference): TrafficSourceCampaign
+{
+    return TrafficSourceCampaign::firstOrCreate(
+        ['traffic_source_id' => $trafficSource->id, 'reference' => $reference],
+        ['name' => 'Campaign '.$reference, 'type' => $trafficSource->type]
+    );
+}
+
+it('rolls a campaign\'s attributed customers and revenue into its own stats', function () {
+    $reference = (string) random_int(10000000000, 99999999999);
+
+    $customer = StoreCustomer::make()->action(
+        $this->shop,
+        array_merge(Customer::factory()->definition(), [
+            'traffic_sources' => '1700000000b'.$reference,
+        ])
+    );
+
+    DB::table('customer_stats')->where('customer_id', $customer->id)->update([
+        'sales_all'                      => 900,
+        'number_orders_state_dispatched' => 3,
+    ]);
+
+    $campaign = TrafficSourceCampaign::where('reference', $reference)->firstOrFail();
+    TrafficSourceCampaignHydrateStats::run($campaign);
+
+    $stats = $campaign->stats()->first();
+
+    expect((float) $stats->number_customers)->toBe(1.0);
+    expect((float) $stats->total_customer_revenue)->toBe(900.0);
+    expect((float) $stats->number_customer_purchases)->toBe(3.0);
+});
+
+it('rolls campaign level spend into the campaign stats', function () {
+    $campaign = campaignFor($this->googleAds, (string) random_int(10000000000, 99999999999));
+
+    StoreTrafficSourceCost::run($this->googleAds, [
+        'date'                       => now()->subDay()->toDateString(),
+        'source_amount'              => 120.00,
+        'source_currency_id'         => $this->shop->currency_id,
+        'traffic_source_campaign_id' => $campaign->id,
+    ]);
+
+    TrafficSourceCampaignHydrateStats::run($campaign);
+
+    expect((float) $campaign->stats()->first()->total_cost)->toBe(120.0);
+});
+
+it('keeps a campaign with spend but no customers visible', function () {
+    $campaign = campaignFor($this->googleAds, (string) random_int(10000000000, 99999999999));
+
+    StoreTrafficSourceCost::run($this->googleAds, [
+        'date'                       => now()->subDay()->toDateString(),
+        'source_amount'              => 75.00,
+        'source_currency_id'         => $this->shop->currency_id,
+        'traffic_source_campaign_id' => $campaign->id,
+    ]);
+
+    TrafficSourceCampaignHydrateStats::run($campaign);
+    $stats = $campaign->stats()->first();
+
+    expect((float) $stats->total_cost)->toBe(75.0);
+    expect((float) $stats->number_customers)->toBe(0.0);
+    expect((float) $stats->total_customer_revenue)->toBe(0.0);
+});
+
+it('never lets a source\'s campaigns claim more than the source itself', function () {
+    $first  = (string) random_int(10000000000, 99999999999);
+    $second = (string) random_int(10000000000, 99999999999);
+
+    $customer = StoreCustomer::make()->action(
+        $this->shop,
+        array_merge(Customer::factory()->definition(), [
+            'traffic_sources' => '1700000000b'.$first.'|1700000100b'.$second,
+        ])
+    );
+
+    DB::table('customer_stats')->where('customer_id', $customer->id)->update(['sales_all' => 1000]);
+
+    TrafficSourceHydrateCustomers::run($this->googleAds);
+
+    $campaignRevenue = 0.0;
+    foreach ([$first, $second] as $reference) {
+        $campaign = TrafficSourceCampaign::where('reference', $reference)->firstOrFail();
+        TrafficSourceCampaignHydrateStats::run($campaign);
+        $campaignRevenue += (float) $campaign->stats()->first()->total_customer_revenue;
+    }
+
+    // The two campaigns split this customer's revenue between them, never duplicating it...
+    expect($campaignRevenue)->toBe(1000.0);
+
+    // ...and campaigns can never claim more than the source they belong to. (Other tests in this file
+    // share the shop, so the source legitimately carries their customers too - hence not equality.)
+    expect($campaignRevenue)
+        ->toBeLessThanOrEqual(round((float) $this->googleAds->stats()->first()->total_customer_revenue, 2));
+});
+
+it('hydrates every campaign through the artisan command', function () {
+    $campaign = campaignFor($this->googleAds, (string) random_int(10000000000, 99999999999));
+
+    StoreTrafficSourceCost::run($this->googleAds, [
+        'date'                       => now()->subDay()->toDateString(),
+        'source_amount'              => 33.00,
+        'source_currency_id'         => $this->shop->currency_id,
+        'traffic_source_campaign_id' => $campaign->id,
+    ]);
+
+    Artisan::call('traffic-source:hydrate-campaign-stats', ['--shop' => $this->shop->slug]);
+
+    expect((float) $campaign->stats()->first()->total_cost)->toBe(33.0);
+});
+
+it('reports campaign performance for the selected period on the dashboard', function () {
+    $reference = (string) random_int(10000000000, 99999999999);
+
+    $customer = StoreCustomer::make()->action(
+        $this->shop,
+        array_merge(Customer::factory()->definition(), [
+            'traffic_sources' => '1700000000b'.$reference,
+        ])
+    );
+
+    $campaign = TrafficSourceCampaign::where('reference', $reference)->firstOrFail();
+
+    DB::table('invoices')->insert([
+        'group_id'        => $this->shop->group_id,
+        'organisation_id' => $this->shop->organisation_id,
+        'shop_id'         => $this->shop->id,
+        'customer_id'     => $customer->id,
+        'currency_id'     => $this->shop->currency_id,
+        'tax_category_id' => App\Models\Helpers\TaxCategory::firstOrFail()->id,
+        'reference'       => 'INV-'.uniqid(),
+        'slug'            => 'inv-'.uniqid(),
+        'type'            => 'invoice',
+        'net_amount'      => 400,
+        'total_amount'    => 400,
+        'in_process'      => false,
+        'payment_data'    => '{}',
+        'data'            => '{}',
+        'date'            => now()->subDay()->toDateTimeString(),
+        'created_at'      => now()->subDay()->toDateTimeString(),
+        'updated_at'      => now()->subDay()->toDateTimeString(),
+    ]);
+
+    StoreTrafficSourceCost::run($this->googleAds, [
+        'date'                       => now()->subDay()->toDateString(),
+        'source_amount'              => 100.00,
+        'source_currency_id'         => $this->shop->currency_id,
+        'traffic_source_campaign_id' => $campaign->id,
+    ]);
+
+    $campaigns = collect(GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::LAST_7)['campaigns'])
+        ->keyBy('name');
+
+    expect($campaigns[$campaign->name]['spend'])->toBe(100.0);
+    expect($campaigns[$campaign->name]['revenue'])->toBe(400.0);
+    expect($campaigns[$campaign->name]['roas'])->toBe(4.0);
+});


### PR DESCRIPTION
Stacked on #2532 (date ranges) — base will retarget to `main` automatically once that merges.

## The table was never usable

`traffic_source_campaign_stats` has existed since July 2025 and **has never been written to**. It shipped with:

```php
$table->unsignedInteger('number_campaigns_type_' . $type);  // one per campaign type
```

That's a *count of campaigns by type* — a parent-level shape copy-pasted onto a single campaign's own stats row. It cannot answer anything about the campaign it belongs to, which is presumably why no hydrator was ever written for it.

Replaced with the same figures `traffic_source_stats` carries: customers, purchases, revenue (shop + org currency), cost (shop + org currency). Counts are `decimal` because attribution shares are fractional.

## The hydrator

`TrafficSourceCampaignHydrateStats` weights everything by attribution share exactly as the source hydrator does, which gives the invariant that matters:

> **A source's campaigns can never claim more than the source itself.**

A customer split between two campaigns contributes half to each — tested directly.

A campaign with spend but **no** attributed customer still gets a row, so money spent with nothing to show for it appears as a bad ROAS rather than vanishing from the report.

Dispatch points:
- `AttachTrafficSourcesToModel` — when attribution writes a campaign pivot row
- `StoreTrafficSourceCost` — when campaign-level spend is imported
- `traffic-source:hydrate-campaign-stats` — backfills existing campaigns, since nothing ever has; safe to rerun, `--shop` scopable

Queued `low-priority`, `ShouldBeUnique` per campaign — same discipline the perf review required of the source hydrator.

## Surfaced

Period-scoped **Campaign performance** table on the marketing dashboard, ranked by money moved, top 8 (campaign refs come from ad platforms, so a shop accumulates hundreds). Revenue is the same invoice-derived, share-weighted figure the channel panel uses, so campaign and channel numbers reconcile instead of being two different calculations.

## Tests

6 tests: attribution rollup, campaign spend rollup, spend-without-customers visibility, the campaigns-never-exceed-source invariant, the backfill command, and period-scoped dashboard output.

All green: 6 campaign + 6 period + 8 attribution.

## Note on ShowTrafficSource

I did **not** add a campaigns tab to `ShowTrafficSource` — that page currently 500s on every load (`customers.traffic_source_id` was dropped in July 2025) and is being fixed in a separate session. Worth adding a tab there once it's alive.