### PR TITLE
🚨 fix: mailshot click attribution records nothing (dead relation)

### DIFF
--- a/app/Actions/Comms/EmailTrackingEvent/StoreEmailTrackingEvent.php
+++ b/app/Actions/Comms/EmailTrackingEvent/StoreEmailTrackingEvent.php
@@ -36,15 +36,17 @@ class StoreEmailTrackingEvent extends OrgAction
                dispatch notices, invoices) reach the same CLICKED state, and recording those would
                hand the newsletter channel a share of every engaged customer's revenue for clicks
                that are post-purchase service, not acquisition. */
-            if ($dispatchedEmail->mailshot) {
+            $mailshot = $dispatchedEmail->sentMailshot;
+
+            if ($mailshot) {
                 $clickedAt = $emailTrackingEvent->created_at ?? now();
 
                 foreach ($dispatchedEmail->customers as $customer) {
-                    RecordEmailClickTouchpoint::dispatch($customer, $clickedAt, $dispatchedEmail->mailshot);
+                    RecordEmailClickTouchpoint::dispatch($customer, $clickedAt, $mailshot);
                 }
 
                 foreach ($dispatchedEmail->prospects as $prospect) {
-                    RecordEmailClickTouchpoint::dispatch($prospect, $clickedAt, $dispatchedEmail->mailshot);
+                    RecordEmailClickTouchpoint::dispatch($prospect, $clickedAt, $mailshot);
                 }
             }
         } elseif ($emailTrackingEvent->type == EmailTrackingEventTypeEnum::OPENED) {

--- a/app/Models/Comms/DispatchedEmail.php
+++ b/app/Models/Comms/DispatchedEmail.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
@@ -69,9 +70,33 @@ class DispatchedEmail extends Model
         return $this->belongsTo(EmailAddress::class);
     }
 
+    /**
+     * `dispatched_emails.mailshot_id` was dropped in May 2025, so this belongsTo resolves against a
+     * column that no longer exists and always returns null. Kept only so existing callers keep
+     * compiling; anything that needs the mailshot must use `sentMailshot()`.
+     *
+     * @deprecated Use sentMailshot()
+     */
     public function mailshot(): BelongsTo
     {
         return $this->belongsTo(Mailshot::class);
+    }
+
+    /**
+     * The mailshot this email was actually sent for, resolved through mailshot_recipients, which is
+     * where the link has lived since the column was dropped. Null for transactional mail, which is
+     * how a marketing touch is told apart from an order confirmation.
+     */
+    public function sentMailshot(): HasOneThrough
+    {
+        return $this->hasOneThrough(
+            Mailshot::class,
+            MailshotRecipient::class,
+            'dispatched_email_id',
+            'id',
+            'id',
+            'mailshot_id'
+        );
     }
 
     public function outbox(): BelongsTo

--- a/tests/Feature/CRM/MailshotClickAttributionTest.php
+++ b/tests/Feature/CRM/MailshotClickAttributionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\Comms\EmailTrackingEvent\StoreEmailTrackingEvent;
+use App\Actions\Comms\Mailshot\StoreMailshot;
+use App\Enums\Comms\EmailTrackingEvent\EmailTrackingEventTypeEnum;
+use App\Enums\Comms\Outbox\OutboxCodeEnum;
+use App\Models\Comms\DispatchedEmail;
+use App\Models\Comms\Mailshot;
+use App\Models\Comms\MailshotRecipient;
+use Illuminate\Support\Facades\Artisan;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->customer = createCustomer($this->shop);
+    $this->outbox   = $this->shop->outboxes()->where('type', OutboxCodeEnum::MARKETING)->first();
+});
+
+function dispatchedEmailFor($outbox, $customer): DispatchedEmail
+{
+    $dispatchedEmail = $outbox->dispatchedEmails()->create([
+        'email_address_id' => $customer->email ? null : null,
+        'data'             => [],
+    ]);
+
+    $customer->dispatchedEmails()->attach($dispatchedEmail);
+
+    return $dispatchedEmail;
+}
+
+it('resolves the mailshot through mailshot_recipients, not the dropped column', function () {
+    $mailshot        = StoreMailshot::make()->action($this->outbox, Mailshot::factory()->definition());
+    $dispatchedEmail = dispatchedEmailFor($this->outbox, $this->customer);
+
+    MailshotRecipient::create([
+        'mailshot_id'         => $mailshot->id,
+        'dispatched_email_id' => $dispatchedEmail->id,
+        'recipient_type'      => 'Customer',
+        'recipient_id'        => $this->customer->id,
+        'channel'             => 1,
+    ]);
+
+    // The legacy relation is dead: its column was dropped in May 2025.
+    expect($dispatchedEmail->fresh()->mailshot)->toBeNull();
+
+    // The working one finds it.
+    expect($dispatchedEmail->fresh()->sentMailshot?->id)->toBe($mailshot->id);
+});
+
+it('queues a touchpoint when a mailshot email is clicked', function () {
+    $mailshot        = StoreMailshot::make()->action($this->outbox, Mailshot::factory()->definition());
+    $dispatchedEmail = dispatchedEmailFor($this->outbox, $this->customer);
+
+    MailshotRecipient::create([
+        'mailshot_id'         => $mailshot->id,
+        'dispatched_email_id' => $dispatchedEmail->id,
+        'recipient_type'      => 'Customer',
+        'recipient_id'        => $this->customer->id,
+        'channel'             => 1,
+    ]);
+
+    $this->customer->update(['traffic_sources' => null]);
+
+    StoreEmailTrackingEvent::make()->handle($dispatchedEmail->fresh(), [
+        'type' => EmailTrackingEventTypeEnum::CLICKED,
+        'data' => [],
+    ]);
+
+    expect($this->customer->fresh()->traffic_sources)
+        ->toContain(App\Actions\CRM\TrafficSource\RecordEmailClickTouchpoint::CAMPAIGN_REF_PREFIX.$mailshot->id);
+});
+
+it('queues nothing when a transactional email is clicked', function () {
+    $dispatchedEmail = dispatchedEmailFor($this->outbox, $this->customer);
+
+    $this->customer->update(['traffic_sources' => null]);
+
+    StoreEmailTrackingEvent::make()->handle($dispatchedEmail->fresh(), [
+        'type' => EmailTrackingEventTypeEnum::CLICKED,
+        'data' => [],
+    ]);
+
+    expect($this->customer->fresh()->traffic_sources)->toBeNull();
+});


### PR DESCRIPTION
**Production is currently recording zero mailshot attribution.** Found while verifying the deploy.

## What's wrong

`DispatchedEmail::mailshot()` is a `belongsTo(Mailshot::class)` — which resolves on `mailshot_id`, **a column dropped in May 2025** by `2025_05_21_075110_remove_mailshot_id_from_dispatched_emails_table`. The relation has returned `null` for over a year.

The transactional-click guard I added after the hostile review (correctly, per finding C2) tests exactly that relation:

```php
if ($dispatchedEmail->mailshot) {   // always null
```

So instead of separating marketing clicks from service clicks, it discards **both**.

## Production evidence

| | |
|---|---|
| mailshot clicks, last 2h | **245** |
| transactional clicks, last 2h | 14 |
| newsletter touches recorded | **0** |
| customers with a newsletter touch | **0** |

Every one of those 245 clicks was parsed, accepted, and dropped.

## The fix

`sentMailshot()` — a `hasOneThrough` via `mailshot_recipients`, which is where the link has actually lived since the column was dropped (10.3M rows, `dispatched_email_id` indexed). Transactional mail still resolves to `null`, so the guard keeps doing what it was added for.

The dead `belongsTo` is kept and marked `@deprecated` — removing it is a wider change than this fix should carry, and nothing else calls it.

## Tests

3 tests, asserting real outcomes rather than mocked queue pushes:
- the legacy relation returns null while `sentMailshot()` finds the mailshot — this test fails on the old code
- a mailshot click writes the touch **with its campaign reference**
- a transactional click writes nothing

Plus the existing 10 touchpoint tests still green.

## Deploy note

Needs deploying to start capturing. Clicks dropped before then are not recoverable as touches — the SES events survive in `email_tracking_events`, but no touch was ever written.