### PR TITLE
🩹 fix: ShowTrafficSource 500s on every load

### DIFF
--- a/app/Actions/CRM/Customer/UI/IndexCustomers.php
+++ b/app/Actions/CRM/Customer/UI/IndexCustomers.php
@@ -406,7 +406,17 @@ class IndexCustomers extends OrgAction
 
             $allowedSort = array_merge(['organisation_name', 'shop_name'], $allowedSort);
         } elseif (class_basename($parent) == 'TrafficSource') {
-            $queryBuilder->where('customers.traffic_source_id', $parent->id);
+            /* customers.traffic_source_id was dropped in July 2025 when attribution became
+               many-to-many: a customer can be credited to several sources, each with a share. The
+               link lives in model_has_traffic_sources now, and the share rides along so the listing
+               can show how much of each customer this source actually earned. */
+            $queryBuilder
+                ->join('model_has_traffic_sources', function ($join) use ($parent) {
+                    $join->on('model_has_traffic_sources.model_id', '=', 'customers.id')
+                        ->where('model_has_traffic_sources.model_type', '=', 'Customer')
+                        ->where('model_has_traffic_sources.traffic_source_id', '=', $parent->id);
+                })
+                ->addSelect('model_has_traffic_sources.share as attribution_share');
         } elseif (class_basename($parent) == 'Organisation') {
             $queryBuilder
                 ->where('customers.organisation_id', $parent->id)
@@ -575,6 +585,12 @@ class IndexCustomers extends OrgAction
                 ->column(key: 'last_invoiced_at', label: __('Last Invoice'), canBeHidden: false, sortable: true, searchable: true, type: 'date')
                 ->column(key: 'number_invoices_type_invoice', label: __('Invoices'), canBeHidden: false, sortable: true, searchable: true)
                 ->column(key: 'sales_all', label: __('Sales'), canBeHidden: false, sortable: true, searchable: true);
+
+            /* A customer touched by several channels is only partly this source's, so show the share
+               rather than implying the source earned the whole of the sales beside it. */
+            if ($parent instanceof TrafficSource) {
+                $table->column(key: 'attribution_share', label: __('Attribution'), canBeHidden: true, sortable: true);
+            }
 
             $table->column(
                 key: 'tags',

--- a/app/Http/Resources/CRM/CustomersResource.php
+++ b/app/Http/Resources/CRM/CustomersResource.php
@@ -29,6 +29,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @property mixed $sales_org_currency_all
  * @property mixed $sales_grp_currency_all
  * @property mixed $number_invoices_type_invoice
+ * @property mixed $attribution_share
  * @property mixed $number_current_portfolios
  * @property mixed $currency_code
  * @property bool $is_dropshipping
@@ -70,6 +71,8 @@ class CustomersResource extends JsonResource
             'number_customer_sales_channels'  => $this->number_customer_sales_channels,
             'last_invoiced_at'                => $this->last_invoiced_at,
             'number_invoices_type_invoice'    => $this->number_invoices_type_invoice,
+            /* Only present when the listing is scoped to a traffic source, which joins it in. */
+            'attribution_share'               => $this->attribution_share ?? null,
             'sales_all'                       => $this->sales_all,
             'sales_org_currency_all'          => $this->sales_org_currency_all,
             'sales_grp_currency_all'          => $this->sales_grp_currency_all,

--- a/tests/Feature/CRM/ShowTrafficSourceTest.php
+++ b/tests/Feature/CRM/ShowTrafficSourceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\CRM\Customer\UI\IndexCustomers;
+use App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution;
+use App\Actions\CRM\TrafficSource\UI\TrafficSourceTabsEnum;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Artisan;
+
+beforeAll(function () {
+    loadDB();
+});
+
+function fakeRouteForCustomers(): void
+{
+    $route = (new Route('GET', '/_test', []))->name('test.traffic_sources.show');
+
+    request()->setRouteResolver(fn () => $route);
+}
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->googleAds = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+    $this->organic   = createTrafficSource($this->shop, 'organic-google', 'Organic Google');
+
+    $this->customer = createCustomer($this->shop);
+    $this->customer->trafficSources()->detach();
+});
+
+it('lists the customers attributed to a traffic source', function () {
+    $this->customer->update(['traffic_sources' => '1700000000b']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    fakeRouteForCustomers();
+
+    $customers = IndexCustomers::make()->handle($this->googleAds, TrafficSourceTabsEnum::CUSTOMERS->value);
+
+    expect($customers->pluck('id'))->toContain($this->customer->id);
+});
+
+it('shows how much of a shared customer the source actually owns', function () {
+    $this->customer->update(['traffic_sources' => '1700000000b|1700000100a']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    fakeRouteForCustomers();
+
+    $row = IndexCustomers::make()->handle($this->googleAds, TrafficSourceTabsEnum::CUSTOMERS->value)
+        ->firstWhere('id', $this->customer->id);
+
+    expect((float) $row->attribution_share)->toBe(0.5);
+});
+
+it('excludes customers attributed to a different source', function () {
+    $this->customer->update(['traffic_sources' => '1700000000b']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    fakeRouteForCustomers();
+
+    $customers = IndexCustomers::make()->handle($this->organic, TrafficSourceTabsEnum::CUSTOMERS->value);
+
+    expect($customers->pluck('id'))->not->toContain($this->customer->id);
+});


### PR DESCRIPTION
`/marketing/traffic-sources/{slug}` throws a `QueryException` on every load:

```
column customers.traffic_source_id does not exist
```

`IndexCustomers` filters on that column, which was dropped in July 2025 by `remove_traffic_source_id_from_customers_and_crm_table` when attribution became many-to-many. The page has been dead since.

Joins `model_has_traffic_sources` instead, and carries `share` through as an **Attribution** column — a customer touched by several channels is only partly this source's, and showing their full lifetime sales beside the source name implies otherwise.

3 tests: lists attributed customers, shows the fractional share for a shared customer (0.50), excludes customers belonging to another source. All fail on the old code.