### PR TITLE
🛤️ feat(crm): customer marketing journey timeline

### DIFF
--- a/app/Actions/CRM/Customer/UI/GetCustomerJourney.php
+++ b/app/Actions/CRM/Customer/UI/GetCustomerJourney.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\Customer\UI;
+
+use App\Actions\CRM\TrafficSource\ParseTrafficSourceTouches;
+use App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum;
+use App\Models\CRM\Customer;
+use App\Models\CRM\TrafficSourceCampaign;
+use Illuminate\Support\Carbon;
+use Lorisleiva\Actions\Concerns\AsObject;
+
+class GetCustomerJourney
+{
+    use AsObject;
+
+    /**
+     * Builds the read-only marketing journey of a customer: every recorded traffic source touch and
+     * every issued invoice, interleaved on a single time axis, plus the resulting attribution split.
+     *
+     * @return array{events: array<int, array<string, mixed>>, attribution: array<int, array{label: string, share: float, campaign: string|null}>, attribution_window_days: int, currency_code: string}
+     */
+    public function handle(Customer $customer): array
+    {
+        $windowDays = $this->attributionWindowDays($customer);
+        $labels     = TrafficSourcesTypeEnum::labels();
+
+        $invoices = $customer->invoices()
+            ->where('in_process', false)
+            ->orderBy('date')
+            ->get(['id', 'reference', 'date', 'net_amount']);
+
+        $touches = collect(ParseTrafficSourceTouches::run($customer->traffic_sources))
+            ->filter(fn (array $touch) => $touch['timestamp'] !== null)
+            ->sortBy('timestamp')
+            ->values();
+
+        $campaignNames = $this->campaignNames($touches->pluck('campaign_ref')->filter()->unique()->all());
+
+        $events = [];
+
+        foreach ($touches as $index => $touch) {
+            $date         = Carbon::createFromTimestamp($touch['timestamp']);
+            $nextPurchase = $invoices->first(fn ($invoice) => $invoice->date->greaterThanOrEqualTo($date));
+            $deadline     = $nextPurchase?->date ?? now();
+
+            $events[] = [
+                'id'            => 'touch-'.$index,
+                'type'          => 'touch',
+                'datetime'      => $date->toIso8601String(),
+                'channel'       => $touch['type']->value,
+                'label'         => $labels[$touch['type']->value],
+                'is_paid'       => $touch['type']->isPaid(),
+                'campaign_ref'  => $touch['campaign_ref'],
+                'campaign_name' => $touch['campaign_ref'] ? ($campaignNames[$touch['campaign_ref']] ?? null) : null,
+                'in_window'     => $date->greaterThanOrEqualTo($deadline->copy()->subDays($windowDays)),
+                'days_to_next_purchase' => $nextPurchase ? $date->diffInDays($nextPurchase->date) : null,
+            ];
+        }
+
+        foreach ($invoices as $invoice) {
+            $events[] = [
+                'id'         => 'invoice-'.$invoice->id,
+                'type'       => 'invoice',
+                'datetime'   => $invoice->date->toIso8601String(),
+                'label'      => $invoice->reference,
+                'net_amount' => (float) $invoice->net_amount,
+            ];
+        }
+
+        usort($events, fn (array $a, array $b) => [$a['datetime'], $a['type']] <=> [$b['datetime'], $b['type']]);
+
+        return [
+            'events'                  => $events,
+            'attribution'             => $this->attribution($customer, $labels),
+            'attribution_window_days' => $windowDays,
+            'currency_code'           => $customer->shop->currency->code,
+        ];
+    }
+
+    /**
+     * @return array<int, array{label: string, share: float, campaign: string|null}>
+     */
+    private function attribution(Customer $customer, array $labels): array
+    {
+        return $customer->trafficSources->map(function ($trafficSource) use ($labels) {
+            $campaignId = $trafficSource->pivot->traffic_source_campaign_id;
+
+            return [
+                'label'    => $labels[$trafficSource->type] ?? $trafficSource->type,
+                'share'    => (float) $trafficSource->pivot->share,
+                'campaign' => $campaignId ? TrafficSourceCampaign::find($campaignId)?->name : null,
+            ];
+        })->all();
+    }
+
+    /**
+     * @param array<int, string> $references
+     *
+     * @return array<string, string>
+     */
+    private function campaignNames(array $references): array
+    {
+        if (empty($references)) {
+            return [];
+        }
+
+        return TrafficSourceCampaign::whereIn('reference', $references)
+            ->pluck('name', 'reference')
+            ->all();
+    }
+
+    private function attributionWindowDays(Customer $customer): int
+    {
+        return (int) (data_get($customer->shop->settings, 'marketing.attribution_window_days')
+            ?? config('marketing.attribution_window_days', 90));
+    }
+}

--- a/app/Actions/CRM/Customer/UI/ShowCustomer.php
+++ b/app/Actions/CRM/Customer/UI/ShowCustomer.php
@@ -209,6 +209,10 @@ class ShowCustomer extends OrgAction
                     fn () => GetCustomerTimeline::run($customer)
                     : Inertia::optional(fn () => GetCustomerTimeline::run($customer)),
 
+                CustomerTabsEnum::JOURNEY->value  => $this->tab == CustomerTabsEnum::JOURNEY->value ?
+                    fn () => GetCustomerJourney::run($customer)
+                    : Inertia::optional(fn () => GetCustomerJourney::run($customer)),
+
                 $tabs::HISTORY->value             => $this->tab == $tabs::HISTORY->value ?
                     fn () => HistoryResource::collection(IndexHistory::run($customer))
                     : Inertia::optional(fn () => HistoryResource::collection(IndexHistory::run($customer))),

--- a/app/Enums/UI/CRM/CustomerTabsEnum.php
+++ b/app/Enums/UI/CRM/CustomerTabsEnum.php
@@ -18,6 +18,7 @@ enum CustomerTabsEnum: string
 
     case SHOWCASE            = 'showcase';
     case TIMELINE            = 'timeline';
+    case JOURNEY             = 'journey';
 
     case HISTORY             = 'history';
     case ATTACHMENTS         = 'attachments';
@@ -39,6 +40,11 @@ enum CustomerTabsEnum: string
             CustomerTabsEnum::TIMELINE => [
                 'title' => __('Timeline'),
                 'icon'  => 'fal fa-code-branch',
+            ],
+
+            CustomerTabsEnum::JOURNEY => [
+                'title' => __('Journey'),
+                'icon'  => 'fal fa-route',
             ],
 
             CustomerTabsEnum::HISTORY => [

--- a/resources/js/Components/Showcases/Grp/CustomerJourney.vue
+++ b/resources/js/Components/Showcases/Grp/CustomerJourney.vue
@@ -1,0 +1,92 @@
+<!--
+  - Author: Raul Perusquia <raul@inikoo.com>
+  - Created: Fri, 07 Aug 2026
+  - Copyright (c) 2026, Raul A Perusquia Flores
+  -->
+
+<script setup lang="ts">
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faBullseyeArrow, faFileInvoiceDollar, faRoute } from '@fal'
+import { useFormatTime } from '@/Composables/useFormatTime'
+import { useLocaleStore } from '@/Stores/locale'
+import { trans } from 'laravel-vue-i18n'
+
+library.add(faBullseyeArrow, faFileInvoiceDollar, faRoute)
+
+interface JourneyEvent {
+    id: string
+    type: 'touch' | 'invoice'
+    datetime: string
+    label: string
+    channel?: string
+    is_paid?: boolean
+    campaign_ref?: string | null
+    campaign_name?: string | null
+    in_window?: boolean
+    days_to_next_purchase?: number | null
+    net_amount?: number
+}
+
+const props = defineProps<{
+    data?: {
+        events: JourneyEvent[]
+        attribution: { label: string, share: number, campaign: string | null }[]
+        attribution_window_days: number
+        currency_code: string
+    }
+}>()
+
+const locale = useLocaleStore()
+</script>
+
+<template>
+    <div v-if="data" class="px-4 py-6 max-w-4xl">
+        <div class="mb-6 border-b border-gray-200 pb-4">
+            <div class="text-xs uppercase tracking-wide text-gray-400">{{ trans('Attribution') }}</div>
+            <div v-if="data.attribution.length" class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+                <span v-for="(item, index) in data.attribution" :key="index" class="text-sm text-gray-700">
+                    {{ item.label }}<span v-if="item.campaign" class="text-gray-400"> / {{ item.campaign }}</span>
+                    <span class="ml-1 tabular-nums text-gray-500">{{ item.share.toFixed(2) }}</span>
+                </span>
+            </div>
+            <div v-else class="mt-1 text-sm text-gray-400">{{ trans('No attribution recorded') }}</div>
+            <div class="mt-1 text-xs text-gray-400">
+                {{ trans('Attribution window') }}: {{ data.attribution_window_days }} {{ trans('days') }}
+            </div>
+        </div>
+
+        <div v-if="!data.events.length" class="text-sm text-gray-400">
+            {{ trans('No marketing touches or invoices recorded for this customer') }}
+        </div>
+
+        <ol v-else class="relative border-l border-gray-200 ml-3">
+            <li v-for="event in data.events" :key="event.id" class="mb-6 ml-6">
+                <span
+                    class="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full ring-4 ring-white"
+                    :class="event.type === 'invoice' ? 'bg-emerald-100 text-emerald-600' : (event.in_window ? 'bg-indigo-100 text-indigo-600' : 'bg-gray-100 text-gray-400')">
+                    <FontAwesomeIcon :icon="event.type === 'invoice' ? 'fal fa-file-invoice-dollar' : 'fal fa-bullseye-arrow'" class="text-xs" fixed-width />
+                </span>
+
+                <div class="flex items-baseline justify-between gap-4">
+                    <div :class="event.type === 'touch' && !event.in_window ? 'text-gray-400' : 'text-gray-700'">
+                        <span class="text-sm">{{ event.label }}</span>
+                        <span v-if="event.campaign_name || event.campaign_ref" class="ml-1 text-xs text-gray-400">
+                            {{ event.campaign_name ?? event.campaign_ref }}
+                        </span>
+                    </div>
+                    <div class="whitespace-nowrap text-xs tabular-nums text-gray-400">
+                        <span v-if="event.type === 'invoice'" class="mr-2 text-sm text-emerald-600">
+                            {{ locale.currencyFormat(data.currency_code, event.net_amount ?? 0) }}
+                        </span>
+                        {{ useFormatTime(event.datetime) }}
+                    </div>
+                </div>
+
+                <div v-if="event.type === 'touch' && !event.in_window" class="text-xs text-gray-400">
+                    {{ trans('Outside attribution window') }}
+                </div>
+            </li>
+        </ol>
+    </div>
+</template>

--- a/resources/js/Pages/Grp/Org/Shop/CRM/Customer.vue
+++ b/resources/js/Pages/Grp/Org/Shop/CRM/Customer.vue
@@ -15,6 +15,7 @@ import Tabs from "@/Components/Navigation/Tabs.vue"
 import TableProducts from "@/Components/Tables/Grp/Org/Catalogue/TableProducts.vue"
 import CustomerShowcase from "@/Components/Showcases/Grp/CustomerShowcase.vue"
 import CustomerTimeline from "@/Components/Showcases/Grp/CustomerTimeline.vue"
+import CustomerJourney from "@/Components/Showcases/Grp/CustomerJourney.vue"
 import TableWebUsers from "@/Components/Tables/Grp/Org/CRM/TableWebUsers.vue"
 import { PageHeadingTypes } from "@/types/PageHeading"
 import ModelDetails from "@/Components/ModelDetails.vue"
@@ -27,7 +28,7 @@ import UploadAttachment from "@/Components/Upload/UploadAttachment.vue"
 import Button from "@/Components/Elements/Buttons/Button.vue"
 import TableHistories from "@/Components/Tables/Grp/Helpers/TableHistories.vue"
 import { library } from "@fortawesome/fontawesome-svg-core"
-import { faCodeCommit, faUsers, faGlobe, faGraduationCap, faMoneyBill, faPaperclip, faPaperPlane, faStickyNote, faTags, faCube, faCodeBranch, faShoppingCart, faHeart, faQuestionCircle, faLightbulbOn } from "@fal"
+import { faCodeCommit, faUsers, faGlobe, faGraduationCap, faMoneyBill, faPaperclip, faPaperPlane, faStickyNote, faTags, faCube, faCodeBranch, faShoppingCart, faHeart, faQuestionCircle, faLightbulbOn, faRoute } from "@fal"
 import { routeType } from "@/types/route"
 import { AddressManagement } from "@/types/PureComponent/Address"
 import TableCreditTransactions from "@/Components/Tables/Grp/Org/Accounting/TableCreditTransactions.vue"
@@ -40,7 +41,7 @@ import SelectableCardGrid from "@/Components/Utils/SelectableCardGrid.vue"
 import { useForm } from "@inertiajs/vue3"
 import LoadingOverlay from "@/Components/Utils/LoadingOverlay.vue"
 
-library.add(faStickyNote, faUsers, faGlobe, faMoneyBill, faGraduationCap, faTags, faCodeCommit, faPaperclip, faPaperPlane, faCube, faCodeBranch, faShoppingCart, faHeart, faQuestionCircle, faLightbulbOn)
+library.add(faStickyNote, faUsers, faGlobe, faMoneyBill, faGraduationCap, faTags, faCodeCommit, faPaperclip, faPaperPlane, faCube, faCodeBranch, faShoppingCart, faHeart, faQuestionCircle, faLightbulbOn, faRoute)
 
 
 const props = defineProps<{
@@ -69,6 +70,7 @@ const props = defineProps<{
     favourites?: {}
     reminders?: {}
     timeline?: {}
+    journey?: {}
     history?: {}
     credit_transactions?: {}
     payments?: {}
@@ -119,6 +121,7 @@ const component = computed(() => {
     const components: Component = {
         showcase: CustomerShowcase,
         timeline: CustomerTimeline,
+        journey: CustomerJourney,
         products: TableProducts,
         orders: TableOrders,
         details: ModelDetails,

--- a/tests/Feature/CRM/CustomerJourneyTest.php
+++ b/tests/Feature/CRM/CustomerJourneyTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\Accounting\Invoice\StoreInvoice;
+use App\Actions\CRM\Customer\StoreCustomer;
+use App\Actions\CRM\Customer\UI\GetCustomerJourney;
+use App\Models\Accounting\Invoice;
+use App\Models\Catalogue\Shop;
+use App\Models\CRM\Customer;
+use Illuminate\Support\Facades\Artisan;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    createTrafficSource($this->shop, 'organic-google', 'Organic Google');
+    createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+});
+
+function journeyCustomer(Shop $shop, ?string $trafficSources): Customer
+{
+    return StoreCustomer::make()->action(
+        $shop,
+        array_merge(Customer::factory()->definition(), [
+            'traffic_sources' => $trafficSources,
+        ])
+    );
+}
+
+function journeyInvoice(Customer $customer, string $date, float $netAmount): Invoice
+{
+    return StoreInvoice::make()->action(
+        $customer,
+        array_merge(Invoice::factory()->definition(), [
+            'date'       => $date,
+            'net_amount' => $netAmount,
+            'in_process' => false,
+        ])
+    );
+}
+
+it('interleaves touches and invoices in chronological order', function () {
+    $touchA = now()->subDays(20)->timestamp;
+    $touchB = now()->subDays(5)->timestamp;
+
+    $customer = journeyCustomer($this->shop, $touchA.'a|'.$touchB.'b');
+    journeyInvoice($customer, now()->subDays(10)->toDateTimeString(), 100);
+
+    $journey = GetCustomerJourney::run($customer->refresh());
+
+    expect(array_column($journey['events'], 'type'))->toBe(['touch', 'invoice', 'touch']);
+    expect($journey['events'][1]['net_amount'])->toBe(100.0);
+    expect($journey['events'][0]['label'])->toBe('Organic Google');
+});
+
+it('returns an empty journey for a customer with no touches and no invoices', function () {
+    $customer = journeyCustomer($this->shop, null);
+
+    $journey = GetCustomerJourney::run($customer->refresh());
+
+    expect($journey['events'])->toBe([])
+        ->and($journey['attribution'])->toBe([])
+        ->and($journey['attribution_window_days'])->toBe(90);
+});
+
+it('flags a touch that falls outside the attribution window of the following purchase', function () {
+    $staleTouch  = now()->subDays(200)->timestamp;
+    $recentTouch = now()->subDays(3)->timestamp;
+
+    $customer = journeyCustomer($this->shop, $staleTouch.'a|'.$recentTouch.'b');
+    journeyInvoice($customer, now()->toDateTimeString(), 50);
+
+    $journey = GetCustomerJourney::run($customer->refresh());
+
+    $touches = array_values(array_filter($journey['events'], fn ($event) => $event['type'] === 'touch'));
+
+    expect($touches[0]['in_window'])->toBeFalse()
+        ->and($touches[1]['in_window'])->toBeTrue();
+});
+
+it('honours the per shop attribution window override', function () {
+    $touch = now()->subDays(30)->timestamp;
+
+    $this->shop->settings = array_merge($this->shop->settings ?? [], [
+        'marketing' => ['attribution_window_days' => 7],
+    ]);
+    $this->shop->save();
+
+    $customer = journeyCustomer($this->shop, $touch.'a');
+
+    $journey = GetCustomerJourney::run($customer->refresh());
+
+    expect($journey['attribution_window_days'])->toBe(7)
+        ->and($journey['events'][0]['in_window'])->toBeFalse();
+});


### PR DESCRIPTION
Adds a read-only **Journey** tab to the customer show page: every recorded marketing touch and every issued invoice interleaved on one time axis, so "touched here, bought there" is visible without SQL.

- `GetCustomerJourney` builds the event list from `customers.traffic_sources` (via `ParseTrafficSourceTouches`) plus non-in-process invoices, and returns the attribution split from the `model_has_traffic_sources` pivot.
- A touch is flagged `in_window` when it falls within the attribution window of the next purchase after it (or of now, when no purchase followed). Window is `settings.marketing.attribution_window_days` per shop, falling back to `config('marketing.attribution_window_days', 90)` — the config file itself lands with `feature/attribution-window`, so this reads the 90-day default until then.
- Out-of-window touches render greyed with an explicit label; invoices show `net_amount` via `useLocaleStore().currencyFormat`.

No files touched by PR #2537 or `feature/attribution-window`.

Tests: `tests/Feature/CRM/CustomerJourneyTest.php` — ordering, empty customer, out-of-window flag, per-shop window override. 4 passed.