### PR TITLE
✨ Automated Google Ads cost ingestion (token-scoped webhook + Ads scripts + docs)

### DIFF
--- a/app/Actions/CRM/TrafficSource/ReceiveTrafficSourceCostWebhook.php
+++ b/app/Actions/CRM/TrafficSource/ReceiveTrafficSourceCostWebhook.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+use App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum;
+use App\Models\Catalogue\Shop;
+use App\Models\CRM\TrafficSource;
+use App\Models\CRM\TrafficSourceCampaign;
+use App\Models\Helpers\Currency;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
+use Laravel\Sanctum\PersonalAccessToken;
+use Lorisleiva\Actions\ActionRequest;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+/**
+ * Receives a day of advertising spend posted by an ad platform script (see docs/google-ads-cost-ingestion).
+ *
+ * The bearer token is a Sanctum token whose tokenable *is* the shop, so a token cannot address a shop
+ * other than the one it was minted for: there is no shop id in the credential path at all, and the
+ * optional `shop` field in the body is only a sanity check against the wrong token being pasted into
+ * the wrong account's script. Tokens are hashed at rest, named, and revocable one at a time, which is
+ * what an external agency holding one for a single shop requires.
+ */
+class ReceiveTrafficSourceCostWebhook
+{
+    use AsAction;
+
+    public const ABILITY = 'traffic-source-costs';
+
+    private Shop $shop;
+
+    public function authorize(ActionRequest $request): bool
+    {
+        $token = PersonalAccessToken::findToken((string) $request->bearerToken());
+
+        if (!$token || !$token->can(self::ABILITY) || !$token->tokenable instanceof Shop) {
+            return false;
+        }
+
+        $shopSlug = $request->input('shop');
+
+        if (filled($shopSlug) && $shopSlug !== $token->tokenable->slug) {
+            return false;
+        }
+
+        $token->forceFill(['last_used_at' => now()])->save();
+
+        $this->shop = $token->tokenable;
+
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'shop'                    => ['sometimes', 'string'],
+            'source'                  => ['required', Rule::in(TrafficSourcesTypeEnum::values())],
+            'currency'                => ['required', 'string', 'size:3'],
+            'costs'                   => ['required', 'array', 'min:1'],
+            'costs.*.date'            => ['required', 'date_format:Y-m-d'],
+            'costs.*.amount'          => ['required', 'numeric', 'min:0'],
+            'costs.*.campaign'        => ['nullable', 'string', 'max:255'],
+            'costs.*.campaign_name'   => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function asController(ActionRequest $request): array
+    {
+        $request->validate($this->rules());
+
+        $trafficSource = TrafficSource::where('shop_id', $this->shop->id)
+            ->where('type', $request->input('source'))
+            ->first();
+
+        if (!$trafficSource) {
+            abort(422, "Shop '{$this->shop->slug}' has no '{$request->input('source')}' traffic source.");
+        }
+
+        $currency = Currency::where('code', strtoupper((string) $request->input('currency')))->first();
+
+        if (!$currency) {
+            abort(422, "Unknown currency '{$request->input('currency')}'.");
+        }
+
+        $stored = 0;
+        $errors = [];
+
+        foreach ($request->input('costs') as $index => $cost) {
+            try {
+                StoreTrafficSourceCost::run($trafficSource, [
+                    'date'                       => Arr::get($cost, 'date'),
+                    'source_amount'              => (float) Arr::get($cost, 'amount'),
+                    'source_currency_id'         => $currency->id,
+                    'traffic_source_campaign_id' => $this->campaignId($trafficSource, $cost),
+                ]);
+                $stored++;
+            } catch (\Throwable $e) {
+                /* One unusable line must not cost the caller the rest of the day's spend: the script
+                   posts the whole account in one request and cannot retry a subset. */
+                $errors[] = ['index' => $index, 'message' => $e->getMessage()];
+                Log::warning('Traffic source cost webhook row failed', [
+                    'shop'  => $this->shop->slug,
+                    'cost'  => $cost,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return [
+            'shop'   => $this->shop->slug,
+            'source' => $request->input('source'),
+            'stored' => $stored,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * Campaign references are the ad platform's own numeric campaign ids, which is exactly what the
+     * touch history stores, so no mapping table is needed. A campaign that has had spend but no click
+     * yet has no row, hence firstOrCreate; `reference` is globally unique, so a reference already
+     * claimed by another shop's source falls back to the source-level total rather than mis-crediting.
+     */
+    private function campaignId(TrafficSource $trafficSource, array $cost): ?int
+    {
+        $reference = Arr::get($cost, 'campaign');
+
+        if (blank($reference)) {
+            return null;
+        }
+
+        $campaign = TrafficSourceCampaign::where('reference', $reference)->first();
+
+        if ($campaign) {
+            return $campaign->traffic_source_id === $trafficSource->id ? $campaign->id : null;
+        }
+
+        return TrafficSourceCampaign::create([
+            'traffic_source_id' => $trafficSource->id,
+            'reference'         => $reference,
+            'name'              => Arr::get($cost, 'campaign_name') ?: $reference,
+            'type'              => $trafficSource->type,
+        ])->id;
+    }
+}

--- a/app/Console/Commands/TrafficSourceCostToken.php
+++ b/app/Console/Commands/TrafficSourceCostToken.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Console\Commands;
+
+use App\Actions\CRM\TrafficSource\ReceiveTrafficSourceCostWebhook;
+use App\Models\Catalogue\Shop;
+use Illuminate\Console\Command;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * Mints, lists and revokes the tokens ad-platform scripts use to post spend.
+ *
+ * ponytail: Sanctum's personal access tokens instead of a bespoke tokens table. It already gives
+ * hashed-at-rest storage, a name per holder, individual revocation and, because the token belongs to
+ * the shop, per-shop scoping with no extra column. A new table would only re-implement all of that.
+ */
+class TrafficSourceCostToken extends Command
+{
+    protected $signature = 'traffic-source:cost-token
+                           {shop? : Shop slug}
+                           {name? : Who the token is for, e.g. "AW Advantage"}
+                           {--list : List the tokens of the shop}
+                           {--revoke= : Revoke the token with this id}';
+
+    protected $description = 'Manage the tokens that let an ad platform script post advertising spend';
+
+    public function handle(): int
+    {
+        if ($tokenId = $this->option('revoke')) {
+            $deleted = PersonalAccessToken::where('id', $tokenId)
+                ->where('tokenable_type', Shop::class)
+                ->delete();
+
+            $this->info($deleted ? "Token {$tokenId} revoked." : "No cost token with id {$tokenId}.");
+
+            return $deleted ? Command::SUCCESS : Command::FAILURE;
+        }
+
+        $shop = Shop::where('slug', (string) $this->argument('shop'))->first();
+
+        if (!$shop) {
+            $this->error("Unknown shop '{$this->argument('shop')}'.");
+
+            return Command::FAILURE;
+        }
+
+        if ($this->option('list')) {
+            $this->table(
+                ['id', 'name', 'last used'],
+                $shop->tokens()->get()->map(fn ($token) => [
+                    $token->id,
+                    $token->name,
+                    $token->last_used_at?->toDateTimeString() ?? 'never',
+                ])
+            );
+
+            return Command::SUCCESS;
+        }
+
+        $name = (string) $this->argument('name');
+
+        if ($name === '') {
+            $this->error('A name is required so a leaked token can be identified and revoked on its own.');
+
+            return Command::FAILURE;
+        }
+
+        $token = $shop->createToken($name, [ReceiveTrafficSourceCostWebhook::ABILITY]);
+
+        $this->newLine();
+        $this->info("Token for '{$name}' on shop '{$shop->slug}' (shown once):");
+        $this->line($token->plainTextToken);
+        $this->newLine();
+        $this->line('Endpoint: '.route('webhooks.traffic_source_costs'));
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Models/Catalogue/Shop.php
+++ b/app/Models/Catalogue/Shop.php
@@ -99,6 +99,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use OwenIt\Auditing\Contracts\Auditable;
 use Spatie\MediaLibrary\HasMedia;
+use Laravel\Sanctum\HasApiTokens;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 use App\Models\Ordering\SalesChannel;
@@ -276,6 +277,7 @@ class Shop extends Model implements HasMedia, Auditable
     use HasImage;
     use WithFaireApi;
     use WithReviewIOApi;
+    use HasApiTokens;
 
     protected $casts = [
         'data'                         => 'array',

--- a/docs/google-ads-cost-ingestion/README.md
+++ b/docs/google-ads-cost-ingestion/README.md
@@ -1,0 +1,311 @@
+# Sending Google Ads spend to Aiku automatically
+
+Aiku already knows how much money each advertising campaign **made**. It does not know how much
+each campaign **cost** until someone tells it. That is what this page is about.
+
+Once spend is arriving, the marketing dashboard can show ROAS — return on ad spend, i.e. revenue
+divided by cost. Until then ROAS shows a dash, because dividing by a cost nobody has entered is
+not possible.
+
+The old way was to export a CSV from Google Ads every month and hand it to a developer. The new
+way is a small script that lives inside your Google Ads account and sends yesterday's spend to
+Aiku every night, on its own, forever. Setting it up takes about ten minutes, once.
+
+**Who this is for:** anyone who manages a Google Ads account for one of our shops — our own
+marketing staff, or an outside agency. You do not need to understand any code. You will copy
+some text, paste it in two places, and press a few buttons.
+
+---
+
+## Before you start
+
+You need three things:
+
+1. **Access to the Google Ads account** with permission to create scripts. In Google Ads terms
+   this is "Standard" or "Admin" access. If you can see **Tools & Settings** in the top menu and
+   there is a **Scripts** entry under **Bulk Actions**, you have it.
+2. **Your shop code.** This is the short code Aiku uses for the shop the Ads account advertises,
+   e.g. `aw` or `uk`. If you do not know it, ask whoever gave you the token — it is written on
+   the same message.
+3. **Your token.** This is a long secret string, roughly like
+   `47|kQ8vNc3ZpR9wLxT2mF6yH4bJ0sD1aG5eU7iO`. See the next section for how to get one.
+
+---
+
+## Getting your token
+
+You cannot generate the token yourself. Ask the Aiku team (or your contact at Inikoo) for
+**"a traffic source cost token"**, and tell them:
+
+- which shop it is for, and
+- who will hold it (your name, or your agency's name, e.g. "AW Advantage").
+
+They run one command and send you back a token. Some things worth knowing about it:
+
+- **A token only works for one shop.** It physically cannot write costs for any other shop, even
+  by accident, even if you change the script. If you manage three of our shops you get three
+  tokens.
+- **It is shown once.** Aiku stores only a scrambled version, so nobody — including us — can read
+  it back to you later. If you lose it, we issue a new one and cancel the old one.
+- **It is named after you.** If your token ever leaks it is cancelled on its own, and nobody
+  else's uploads stop.
+- **Treat it like a password.** Do not email it around, do not put it in a shared doc, do not
+  paste it into a support ticket. It goes in one place: the script.
+
+If you ever suspect it has been seen by someone who should not have it, tell us immediately —
+cancelling it takes seconds.
+
+---
+
+## Setting up the script (single Google Ads account)
+
+Do this once per Google Ads account.
+
+### 1. Open the Scripts page
+
+1. Sign in to Google Ads and make sure you are looking at the **right account** — the account
+   name and its ten-digit number appear at the top right. If you manage several, switch to the
+   one you are setting up now.
+2. In the top menu bar click **Tools & Settings** (the spanner icon).
+3. In the column headed **Bulk Actions**, click **Scripts**.
+4. You will land on a page listing scripts (probably empty). Click the round blue **+** button.
+
+### 2. Paste the script
+
+1. You now see a code editor with a few lines of sample text in it, and a name field at the top
+   left saying something like "Untitled script".
+2. Click in the name field and rename it to **Aiku daily cost upload**. This matters only so the
+   next person knows what it is.
+3. Click anywhere inside the big code area, select everything (Ctrl+A on Windows, Cmd+A on Mac)
+   and delete it. The box should be completely empty.
+4. Open the file `google-ads-script.js` that came with this guide, select all of it, copy it, and
+   paste it into the empty box.
+
+### 3. Fill in your three settings
+
+Near the top of what you just pasted there is a short block that looks like this:
+
+```js
+var CONFIG = {
+  ENDPOINT: 'https://aiku.io/webhooks/traffic-source-costs',
+  TOKEN: 'PASTE-YOUR-TOKEN-HERE',
+  SHOP: 'PASTE-YOUR-SHOP-CODE-HERE'
+};
+```
+
+Replace the two placeholder texts, keeping the quote marks around them:
+
+- `PASTE-YOUR-TOKEN-HERE` → your token.
+- `PASTE-YOUR-SHOP-CODE-HERE` → your shop code, e.g. `aw`.
+
+Leave `ENDPOINT` alone unless the message that came with your token gave you a different address
+(it will have, if you are setting this up against a test environment).
+
+A filled-in version looks like:
+
+```js
+var CONFIG = {
+  ENDPOINT: 'https://aiku.io/webhooks/traffic-source-costs',
+  TOKEN: '47|kQ8vNc3ZpR9wLxT2mF6yH4bJ0sD1aG5eU7iO',
+  SHOP: 'aw'
+};
+```
+
+### 4. Authorise it
+
+Google will not let a script talk to the outside world until you say it may.
+
+1. Click **Authorise** (or **Authorize**) — the button is above the code area.
+2. A Google sign-in window pops up. Choose the account you are already signed in with.
+3. You will see a warning that the script wants to "connect to an external service". That is
+   Aiku. Click **Allow**.
+
+If you skip this, the script fails the first time it runs with a permissions error.
+
+### 5. Test it once, by hand
+
+1. Click **Preview** (some accounts call it **Run without changes** or **Run preview**).
+2. Wait — it usually takes ten to thirty seconds.
+3. Look at the **Logs** panel that appears at the bottom.
+
+You want to see two lines roughly like:
+
+```
+Sending 6 campaign(s) for 2026-08-06, total 153.22 GBP for shop aw.
+OK — {"shop":"aw","source":"google-ads","stored":6,"errors":[]}
+```
+
+`stored: 6` means six campaign-days of spend were saved. If you see something else, jump to
+[When it goes wrong](#when-it-goes-wrong) below.
+
+If the log says "No campaign spend on … — nothing to send", that is not an error: the account
+genuinely spent nothing yesterday. Try again after a day with spend.
+
+### 6. Schedule it daily
+
+1. Click **Save**.
+2. Back on the Scripts list, find your script's row and look at the **Frequency** column. It says
+   something like "Not scheduled" or shows a clock icon — click it.
+3. Choose **Daily**, and pick a time. **Early morning, between 05:00 and 08:00 account time, is
+   the right answer.** Google finalises the previous day's figures overnight, and running before
+   they settle can send a slightly low number.
+4. Click **Save**.
+
+That is the whole setup. From tomorrow it runs on its own.
+
+---
+
+## Checking it worked
+
+The next morning, do two checks.
+
+**In Google Ads:** go back to **Tools & Settings > Bulk Actions > Scripts**. Your script's row
+shows the last time it ran and whether it succeeded. A red exclamation mark means the last run
+failed — click the row to read the log.
+
+**In Aiku:** open the shop, go to the **Marketing** dashboard, and pick a date range that
+includes yesterday. You should now see:
+
+- a **Cost** figure that is no longer zero,
+- a **ROAS** figure — a number like `4.2x` — where it previously showed a dash,
+- the same for the individual campaigns in the campaign table underneath.
+
+Costs may take a couple of minutes to appear after the script runs, because Aiku recalculates the
+totals in the background.
+
+Two things that are normal and not worth reporting:
+
+- **The cost in Aiku is in the shop's currency, the one in Google Ads is in the account's.** If
+  the Ads account bills in EUR and the shop sells in GBP, the numbers will not match — Aiku
+  converts using the exchange rate of the day the money was spent, on purpose, so that last
+  quarter's ROAS does not change every time the exchange rate moves.
+- **A campaign shows cost but no revenue.** That campaign genuinely brought no orders in the
+  period, or brought them outside the attribution window.
+
+---
+
+## When it goes wrong
+
+Everything the script does ends up in its log. Open **Tools & Settings > Bulk Actions > Scripts**,
+click the script, and read the **Logs** panel. Match what you see below.
+
+### "Aiku rejected the token (403)"
+
+One of three things:
+
+1. The token was typed or pasted incompletely. It must include the number and the `|` bar at the
+   start. Re-copy it in full.
+2. The `SHOP` code in the script is not the shop the token belongs to. Check the message the
+   token came in.
+3. The token has been cancelled. Ask for a new one.
+
+### "Aiku could not read the data (422)"
+
+Something in the request did not make sense to Aiku. The message after the code says what — most
+often it is a shop that has no Google Ads traffic source set up yet, or a currency Aiku does not
+know. Send us the log line; this one is on our side to fix.
+
+### "Aiku returned 500" or a network / timeout error
+
+Aiku had a problem, or was briefly unreachable. Do nothing. The next night's run sends yesterday
+again, and if you want the missed day back, just press **Preview** by hand — it is safe (see
+below). If it fails for two nights running, tell us.
+
+### "authorisation" or "permissions" error
+
+Step 4 was skipped or was authorised by a Google user who has since lost access to the account.
+Click **Authorise** again while signed in as a user with access.
+
+### The script runs fine, but Aiku still shows no cost
+
+- Check you are looking at the right shop and a date range that includes the uploaded day.
+- Check the log actually says `stored` with a number above zero.
+- Give it five minutes and reload.
+
+If it is still empty, tell us the shop, the date, and the log line — that is everything we need.
+
+### Is it safe to run it again?
+
+Yes, always. Aiku stores at most one figure per campaign per day: sending the same day again
+**replaces** that figure, it never adds to it. That is deliberate — Google revises the previous
+day's costs slightly for a day or two after the fact, and the later number is the better one. So
+running the script twice, or re-running it after a failure, cannot inflate your spend.
+
+---
+
+## One script per account, or one script for everything?
+
+Both work. This is the question to answer before you set anything up.
+
+### Per-account scripts
+
+Each Google Ads account gets its own copy of `google-ads-script.js`, with its own token, its own
+schedule, and its own log.
+
+**Use this when** different people or different agencies manage different accounts, or when an
+account is managed from outside your manager account.
+
+- Whoever manages an account holds exactly one token, for exactly one shop, and never sees anyone
+  else's.
+- If a token leaks, one shop stops uploading until it is replaced. Nothing else is affected.
+- Handing an account over to another agency means: issue a new token, cancel the old one. Done.
+- The cost is repetition: setting up ten accounts means doing the ten-minute setup ten times, and
+  checking ten scripts when something breaks.
+
+### One MCC (manager-account) script
+
+`google-ads-script-mcc.js` runs in the manager account and loops over the child accounts you list
+in it, uploading each one.
+
+**Use this when** one team manages all the accounts from a single manager account.
+
+- One script, one schedule, one log with a line per account. Adding an account is one line.
+- **The token scoping does not change.** There is no "manager token" that can write to every
+  shop. The MCC script holds a list of accounts, and each entry carries the token for *its* shop.
+  Aiku deliberately provides no way to create a token that spans shops — spend is written against
+  the shop the token belongs to, and no other.
+- The trade-off is concentration: the manager script contains several tokens in one place, and
+  anyone with edit access to that script can read all of them. Anyone able to edit a script in
+  the manager account can already run reports across every child account, so this does not open
+  a new door, but it does mean a compromised manager account means re-issuing every token in the
+  list rather than one.
+- Second trade-off: shared blast radius. A mistake in the manager script stops every account's
+  upload, not one.
+
+### What we recommend
+
+**Run the MCC script for the accounts your own team manages centrally, and give each external
+agency its own per-account script with its own token.**
+
+Concretely: AW Advantage manages `ancientwisdom.biz` externally, so they get their own token and
+their own copy of the single-account script, in their own Ads account, and nothing they hold can
+touch any other shop. Accounts managed in-house from our manager account go in the MCC script's
+list, where one schedule and one log cover them all.
+
+The two models mix freely. The endpoint cannot tell them apart and does not care — it only ever
+sees a token, and a token is only ever good for one shop.
+
+---
+
+## What actually gets sent (for the curious)
+
+One request per account per day. It contains: the shop code, the word `google-ads`, the account's
+currency, and one line per campaign with the date, the Google campaign id, the campaign name and
+the amount spent. No customer data, no order data, nothing personal. Campaign ids are the same
+numbers Google shows in your Ads account, which is how Aiku lines the cost up against the
+revenue it already attributed to that campaign.
+
+### Issuing and cancelling tokens (Aiku team only)
+
+```
+php artisan traffic-source:cost-token <shop-slug> "AW Advantage"   # mint, prints the token once
+php artisan traffic-source:cost-token <shop-slug> --list           # ids, names, last used
+php artisan traffic-source:cost-token --revoke=<id>                # cancel one, immediately
+```
+
+The mint command prints the exact endpoint URL for the environment it runs in — send that along
+with the token, and the shop slug.
+
+Other ad platforms (Meta, Bing, Pinterest) can use the same endpoint — swap `google-ads` for
+`meta-ads`, `bing-ads`, `pinterest-ads` and post the same shape. The one-off CSV route
+(`traffic-source:import-costs`) still exists for backfilling history.

--- a/docs/google-ads-cost-ingestion/google-ads-script-mcc.js
+++ b/docs/google-ads-cost-ingestion/google-ads-script-mcc.js
@@ -1,0 +1,126 @@
+/**
+ * Aiku — daily Google Ads cost upload (MCC / manager account).
+ *
+ * Same job as google-ads-script.js, but run once from a manager account: it loops over the
+ * child accounts listed in ACCOUNTS and sends each one's spend with that account's own token.
+ *
+ * Note there is still ONE TOKEN PER SHOP. The manager account holds several tokens, it does not
+ * get a master one: a token is only ever valid for the single shop it was issued for, so a shop
+ * can be added, moved to a different agency, or cut off without touching the others.
+ *
+ * Paste into the manager account: Tools & Settings > Bulk Actions > Scripts, then schedule Daily.
+ */
+
+var ENDPOINT = 'https://aiku.io/webhooks/traffic-source-costs';
+
+/** One entry per Google Ads account you want uploaded. customerId is the 123-456-7890 number. */
+var ACCOUNTS = [
+  { customerId: '123-456-7890', shop: 'SHOP-CODE', token: 'TOKEN-FOR-THAT-SHOP' }
+  // , { customerId: '098-765-4321', shop: 'OTHER-SHOP', token: 'TOKEN-FOR-OTHER-SHOP' }
+];
+
+function main() {
+  var failures = [];
+
+  for (var i = 0; i < ACCOUNTS.length; i++) {
+    var entry = ACCOUNTS[i];
+
+    try {
+      uploadAccount(entry);
+    } catch (e) {
+      /* Keep going: one account's bad token must not stop the others from being uploaded. */
+      Logger.log('FAILED ' + entry.customerId + ' (' + entry.shop + '): ' + e.message);
+      failures.push(entry.customerId);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error('Upload failed for: ' + failures.join(', ') + '. See the log above.');
+  }
+}
+
+function uploadAccount(entry) {
+  var accounts = AdsManagerApp.accounts().withIds([entry.customerId]).get();
+
+  if (!accounts.hasNext()) {
+    throw new Error('Account not found under this manager account.');
+  }
+
+  var account = accounts.next();
+  AdsManagerApp.select(account);
+
+  var day = yesterday(account);
+  var payload = buildPayload(account, entry.shop, day);
+
+  if (payload.costs.length === 0) {
+    Logger.log(entry.customerId + ' (' + entry.shop + '): no spend on ' + day.label + '.');
+    return;
+  }
+
+  send(payload, entry.token, day.label, entry.customerId);
+}
+
+function yesterday(account) {
+  var zone = account.getTimeZone();
+  var date = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+
+  return {
+    label: Utilities.formatDate(date, zone, 'yyyy-MM-dd'),
+    report: Utilities.formatDate(date, zone, 'yyyyMMdd')
+  };
+}
+
+function buildPayload(account, shop, day) {
+  var costs = [];
+
+  var rows = AdsApp.report(
+    'SELECT campaign.id, campaign.name, metrics.cost_micros ' +
+    'FROM campaign ' +
+    'WHERE segments.date BETWEEN ' + day.report + ' AND ' + day.report
+  ).rows();
+
+  while (rows.hasNext()) {
+    var row = rows.next();
+    var cost = Number(row['metrics.cost_micros']) / 1000000;
+
+    if (cost <= 0) {
+      continue;
+    }
+
+    costs.push({
+      date: day.label,
+      campaign: String(row['campaign.id']),
+      campaign_name: String(row['campaign.name']),
+      amount: cost
+    });
+  }
+
+  return {
+    shop: shop,
+    source: 'google-ads',
+    currency: account.getCurrencyCode(),
+    costs: costs
+  };
+}
+
+function send(payload, token, dayLabel, customerId) {
+  var response = UrlFetchApp.fetch(ENDPOINT, {
+    method: 'post',
+    contentType: 'application/json',
+    headers: {
+      Authorization: 'Bearer ' + token,
+      Accept: 'application/json'
+    },
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  });
+
+  var code = response.getResponseCode();
+  var body = response.getContentText();
+
+  if (code !== 200) {
+    throw new Error('Aiku returned ' + code + ': ' + body);
+  }
+
+  Logger.log(customerId + ' (' + payload.shop + '): ' + dayLabel + ' — ' + body);
+}

--- a/docs/google-ads-cost-ingestion/google-ads-script.js
+++ b/docs/google-ads-cost-ingestion/google-ads-script.js
@@ -1,0 +1,113 @@
+/**
+ * Aiku — daily Google Ads cost upload (single account).
+ *
+ * Paste this into Tools & Settings > Bulk Actions > Scripts in the Google Ads account,
+ * fill in the three CONFIG values, authorise it, and schedule it Daily.
+ *
+ * Sends yesterday's cost per campaign. Safe to run as many times as you like: the same
+ * day posted twice updates the figure, it never adds to it.
+ */
+
+var CONFIG = {
+  ENDPOINT: 'https://aiku.io/webhooks/traffic-source-costs',
+  TOKEN: 'PASTE-YOUR-TOKEN-HERE',
+  SHOP: 'PASTE-YOUR-SHOP-CODE-HERE'
+};
+
+function main() {
+  var day = yesterday();
+  var payload = buildPayload(AdsApp.currentAccount(), day);
+
+  if (payload.costs.length === 0) {
+    Logger.log('No campaign spend on ' + day.label + ' — nothing to send.');
+    return;
+  }
+
+  send(payload, day.label);
+}
+
+/** Yesterday in the account's own time zone, which is the day Google Ads reports on. */
+function yesterday() {
+  var zone = AdsApp.currentAccount().getTimeZone();
+  var date = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+
+  return {
+    label: Utilities.formatDate(date, zone, 'yyyy-MM-dd'),
+    report: Utilities.formatDate(date, zone, 'yyyyMMdd')
+  };
+}
+
+function buildPayload(account, day) {
+  var currency = account.getCurrencyCode();
+  var costs = [];
+
+  var rows = AdsApp.report(
+    'SELECT campaign.id, campaign.name, metrics.cost_micros ' +
+    'FROM campaign ' +
+    'WHERE segments.date BETWEEN ' + day.report + ' AND ' + day.report
+  ).rows();
+
+  while (rows.hasNext()) {
+    var row = rows.next();
+    var cost = Number(row['metrics.cost_micros']) / 1000000;
+
+    if (cost <= 0) {
+      continue;
+    }
+
+    costs.push({
+      date: day.label,
+      campaign: String(row['campaign.id']),
+      campaign_name: String(row['campaign.name']),
+      amount: cost
+    });
+  }
+
+  return {
+    shop: CONFIG.SHOP,
+    source: 'google-ads',
+    currency: currency,
+    costs: costs
+  };
+}
+
+function send(payload, dayLabel) {
+  var total = 0;
+  for (var i = 0; i < payload.costs.length; i++) {
+    total += payload.costs[i].amount;
+  }
+
+  Logger.log('Sending ' + payload.costs.length + ' campaign(s) for ' + dayLabel +
+             ', total ' + total.toFixed(2) + ' ' + payload.currency +
+             ' for shop ' + payload.shop + '.');
+
+  var response = UrlFetchApp.fetch(CONFIG.ENDPOINT, {
+    method: 'post',
+    contentType: 'application/json',
+    headers: {
+      Authorization: 'Bearer ' + CONFIG.TOKEN,
+      Accept: 'application/json'
+    },
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
+  });
+
+  var code = response.getResponseCode();
+  var body = response.getContentText();
+
+  if (code === 200) {
+    Logger.log('OK — ' + body);
+    return;
+  }
+
+  if (code === 403) {
+    throw new Error('Aiku rejected the token (403). Either the token is wrong or revoked, or ' +
+                    'SHOP does not match the shop the token was issued for. Body: ' + body);
+  }
+
+  if (code === 422) {
+    throw new Error('Aiku could not read the data (422). Body: ' + body);
+  }
+
+  throw new Error('Aiku returned ' + code + '. Body: ' + body);
+}

--- a/routes/grp/webhooks/webhooks.php
+++ b/routes/grp/webhooks/webhooks.php
@@ -9,6 +9,7 @@
 use App\Actions\Accounting\Payment\CheckoutCom\ReceiveCheckoutComPaymentWebhook;
 use App\Actions\Comms\Notifications\GetSnsNotification;
 use App\Actions\CRM\Customer\GoogleAds\CallbackShopGoogleAds;
+use App\Actions\CRM\TrafficSource\ReceiveTrafficSourceCostWebhook;
 use App\Actions\Dropshipping\Allegro\User\AuthenticateAllegroAccount;
 use App\Actions\Dropshipping\Shopify\Fulfilment\Callback\CallbackFetchStock;
 use App\Actions\Dropshipping\Shopify\Fulfilment\Callback\CallbackFulfillmentOrderNotification;
@@ -29,6 +30,7 @@ use Laravel\Nightwatch\Http\Middleware\Sample;
 Route::name('webhooks.')->group(function () {
     Route::post('sns', GetSnsNotification::class)->name('sns')->middleware(Sample::never());
     Route::any('checkout-com-payment', ReceiveCheckoutComPaymentWebhook::class)->name('checkout_com_payment');
+    Route::post('traffic-source-costs', ReceiveTrafficSourceCostWebhook::class)->name('traffic_source_costs');
 });
 
 Route::get('google-ads/callback', CallbackShopGoogleAds::class)->name('google_ads.callback');

--- a/tests/Feature/TrafficSourceCostWebhookTest.php
+++ b/tests/Feature/TrafficSourceCostWebhookTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\Catalogue\Shop\StoreShop;
+use App\Actions\CRM\TrafficSource\ReceiveTrafficSourceCostWebhook;
+use App\Models\Catalogue\Shop;
+use App\Models\CRM\TrafficSourceCampaign;
+use App\Models\CRM\TrafficSourceCost;
+use Illuminate\Support\Facades\Artisan;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->googleAds = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+
+    TrafficSourceCost::where('shop_id', $this->shop->id)->delete();
+
+    $this->token = $this->shop->createToken('Test Agency', [ReceiveTrafficSourceCostWebhook::ABILITY])->plainTextToken;
+});
+
+function postCosts(string $token, array $payload)
+{
+    return test()->withHeaders(['Authorization' => "Bearer {$token}"])
+        ->postJson(route('webhooks.traffic_source_costs'), $payload);
+}
+
+function costPayload(array $overrides = []): array
+{
+    return array_merge([
+        'source'   => 'google-ads',
+        'currency' => test()->shop->currency->code,
+        'costs'    => [
+            ['date' => '2026-08-06', 'campaign' => '21723300927', 'campaign_name' => 'Brand', 'amount' => 153.22],
+        ],
+    ], $overrides);
+}
+
+it('stores spend posted with a valid token', function () {
+    $response = postCosts($this->token, costPayload());
+
+    $response->assertOk()->assertJsonPath('stored', 1);
+
+    $cost = TrafficSourceCost::where('shop_id', $this->shop->id)->first();
+    expect((float) $cost->source_amount)->toBe(153.22)
+        ->and($cost->traffic_source_id)->toBe($this->googleAds->id);
+
+    $campaign = TrafficSourceCampaign::find($cost->traffic_source_campaign_id);
+    expect($campaign->reference)->toBe('21723300927')
+        ->and($campaign->name)->toBe('Brand');
+});
+
+it('rejects a request with no token or a made up one', function () {
+    postCosts('', costPayload())->assertForbidden();
+    postCosts('999|nonsense', costPayload())->assertForbidden();
+
+    expect(TrafficSourceCost::where('shop_id', $this->shop->id)->count())->toBe(0);
+});
+
+it('rejects a token belonging to another shop', function () {
+    $otherShop  = StoreShop::run($this->organisation, Shop::factory()->definition());
+    $otherToken = $otherShop->createToken('Other Agency', [ReceiveTrafficSourceCostWebhook::ABILITY])->plainTextToken;
+
+    postCosts($otherToken, costPayload(['shop' => $this->shop->slug]))->assertForbidden();
+
+    expect(TrafficSourceCost::where('shop_id', $this->shop->id)->count())->toBe(0);
+});
+
+it('rejects a shop token minted for something other than costs', function () {
+    $wrongAbility = $this->shop->createToken('Reporting', ['reports'])->plainTextToken;
+
+    postCosts($wrongAbility, costPayload())->assertForbidden();
+});
+
+it('does not double count when the same day is posted twice', function () {
+    postCosts($this->token, costPayload())->assertOk();
+    postCosts($this->token, costPayload())->assertOk();
+
+    $costs = TrafficSourceCost::where('shop_id', $this->shop->id)->get();
+    expect($costs)->toHaveCount(1)
+        ->and((float) $costs->first()->source_amount)->toBe(153.22);
+});
+
+it('updates the day when a corrected figure is posted', function () {
+    postCosts($this->token, costPayload())->assertOk();
+    postCosts($this->token, costPayload([
+        'costs' => [['date' => '2026-08-06', 'campaign' => '21723300927', 'amount' => 160.00]],
+    ]))->assertOk();
+
+    $costs = TrafficSourceCost::where('shop_id', $this->shop->id)->get();
+    expect($costs)->toHaveCount(1)
+        ->and((float) $costs->first()->source_amount)->toBe(160.00);
+});
+
+it('rejects a malformed payload without writing anything', function () {
+    postCosts($this->token, ['source' => 'google-ads'])->assertStatus(422);
+    postCosts($this->token, costPayload(['source' => 'not-a-source']))->assertStatus(422);
+    postCosts($this->token, costPayload([
+        'costs' => [['date' => '06/08/2026', 'amount' => 'lots']],
+    ]))->assertStatus(422);
+
+    expect(TrafficSourceCost::where('shop_id', $this->shop->id)->count())->toBe(0);
+});
+
+it('rejects an unknown currency', function () {
+    postCosts($this->token, costPayload(['currency' => 'ZZZ']))->assertStatus(422);
+
+    expect(TrafficSourceCost::where('shop_id', $this->shop->id)->count())->toBe(0);
+});


### PR DESCRIPTION
ROAS renders as a dash because `traffic_source_costs` is empty — the only way in today is a hand-reshaped CSV. The Google Ads API needs a developer token with a review lead time; Google Ads Scripts need neither and can POST on a schedule from inside the Ads account. This is that route.

## What's here

- `POST /webhooks/traffic-source-costs` (`ReceiveTrafficSourceCostWebhook`) — a day of per-campaign spend for one shop and one source, written through the existing `StoreTrafficSourceCost`. Nothing about conversion, idempotency or hydration is reimplemented.
- `traffic-source:cost-token` — mint / list / revoke.
- `docs/google-ads-cost-ingestion/` — the scripts to paste into Google Ads (single account and MCC) plus a setup guide written for non-engineers.

Payload is a batch — one request per account per day, not one per campaign — because Ads Scripts have execution limits and a script cannot retry a subset. A single unusable line is reported in the response and logged; the rest of the day still lands.

## Token storage: why Sanctum and not a new table

`Shop` gets `HasApiTokens`. Every requirement was already met by `personal_access_tokens`:

| requirement | how |
|---|---|
| scoped per shop | the token's *tokenable is the shop* — there is no shop id anywhere in the credential path, so a token cannot address another shop even if the caller lies in the body |
| individually revocable | delete one row |
| identifiable | `name` is who holds it ("AW Advantage"), plus `last_used_at` |
| not readable after issue | hashed at rest |

A bespoke `traffic_source_cost_tokens` table would have been a migration, a model and a lookup to re-derive exactly that. The ability `traffic-source-costs` is checked too, so a shop token minted later for something else cannot post spend.

The `shop` field in the body is **not** the authorisation — it is an optional sanity check that fails 403 when it disagrees with the token, so pasting the wrong token into the wrong account's script surfaces immediately instead of silently booking spend against the wrong shop.

Campaign references are the raw numeric Google campaign ids, which is already what attribution stores, so no mapping layer. A campaign with spend but no clicks yet has no row, so it is created on first post; `reference` is globally unique, so one already claimed by another shop's source falls back to the source-level total rather than mis-crediting.

## Per-account script or one MCC script?

Both are shipped; the recommendation is **mixed**, and it is in the docs as well as here.

- **Per-account** — one script, one token, one shop, in the agency's own Ads account. Use for anything managed externally. AW Advantage manages `ancientwisdom.biz`, so they get this: nothing they hold can touch another shop, and handing the account over is issue-one/cancel-one.
- **MCC** — one script, one schedule, one log, a line per child account. Use for accounts our own team manages centrally; adding an account is one line.

**Token scoping is identical in both.** There is no manager-level token and the endpoint provides no way to create one — the MCC script simply carries one token per entry in its account list. What changes is concentration, not scope: the manager script holds several tokens in one editable place (anyone who can edit it can already report across every child account, so it opens no new door, but a compromise means re-issuing every token in the list), and a mistake there stops every upload rather than one.

## Tests

`tests/Feature/TrafficSourceCostWebhookTest.php` — 8 passed: valid token stores and auto-creates the campaign, missing/forged token rejected, another shop's token rejected, wrong-ability token rejected, same day posted twice does not double count, a corrected figure updates in place, malformed payloads and unknown currency 422 with nothing written.

Untouched: `GetShopMarketingOverview`, the hydrators, the marketing SQL views.