### PR TITLE
⏳ feat: 90-day attribution window (configurable per shop)

### DIFF
--- a/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
+++ b/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
@@ -12,6 +12,7 @@ use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceCampaignHydrateStats;
 use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
 use App\Models\CRM\TrafficSource;
 use App\Models\CRM\TrafficSourceCampaign;
+use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -62,6 +63,7 @@ class AttachTrafficSourcesToModel
 
         $touchedSourceIds   = [];
         $touchedCampaignIds = [];
+        $touchDates         = $this->touchDates($touches);
 
         foreach ($shares as $share) {
             /** @var TrafficSource|null $trafficSource */
@@ -75,10 +77,14 @@ class AttachTrafficSourcesToModel
                 ? $this->resolveCampaignId($trafficSource, $share['campaign_ref'])
                 : null;
 
+            $dates = $touchDates[$share['type']->value.'|'.($share['campaign_ref'] ?? '')] ?? null;
+
             $model->trafficSources()->attach($trafficSource->id, [
                 'share'                      => round($share['share'], 2),
                 'traffic_source_campaign_id' => $campaignId,
                 'attribution_model'          => $attributionModel,
+                'first_touch_at'             => $dates['first'] ?? null,
+                'last_touch_at'              => $dates['last'] ?? null,
             ]);
 
             $touchedSourceIds[$trafficSource->id] = true;
@@ -95,6 +101,44 @@ class AttachTrafficSourcesToModel
         foreach (TrafficSourceCampaign::whereIn('id', array_keys($touchedCampaignIds))->get() as $campaign) {
             TrafficSourceCampaignHydrateStats::dispatch($campaign);
         }
+    }
+
+    /**
+     * When each source-and-campaign combination was first and last seen. Revenue attribution needs
+     * this: without it a touch recorded today can be credited with purchases made years earlier.
+     *
+     * @param array<int, array{timestamp: int|null, abbr: string, type: TrafficSourcesTypeEnum, campaign_ref: string|null}> $touches
+     *
+     * @return array<string, array{first: Carbon|null, last: Carbon|null}>
+     */
+    private function touchDates(array $touches): array
+    {
+        $dates = [];
+
+        foreach ($touches as $touch) {
+            if ($touch['timestamp'] === null) {
+                continue;
+            }
+
+            $key  = $touch['type']->value.'|'.($touch['campaign_ref'] ?? '');
+            $when = Carbon::createFromTimestamp($touch['timestamp']);
+
+            if (!isset($dates[$key])) {
+                $dates[$key] = ['first' => $when, 'last' => $when];
+
+                continue;
+            }
+
+            if ($when->lt($dates[$key]['first'])) {
+                $dates[$key]['first'] = $when;
+            }
+
+            if ($when->gt($dates[$key]['last'])) {
+                $dates[$key]['last'] = $when;
+            }
+        }
+
+        return $dates;
     }
 
     private function resolveCampaignId(TrafficSource $trafficSource, string $reference): ?int

--- a/app/Actions/CRM/TrafficSource/GetAttributionWindow.php
+++ b/app/Actions/CRM/TrafficSource/GetAttributionWindow.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+use App\Models\Catalogue\Shop;
+use Illuminate\Support\Arr;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetAttributionWindow
+{
+    use AsAction;
+
+    /**
+     * How many days after a touch that channel may still claim a customer's revenue.
+     *
+     * A shop can override the group default through `settings.marketing.attribution_window_days`,
+     * because reorder cycles differ: a dropshipping shop converts in days, wholesale in months.
+     * Zero or negative disables the window, which restores the old behaviour of crediting a
+     * channel with everything a customer ever spent - only ever useful for comparison.
+     */
+    public function handle(Shop $shop): int
+    {
+        $shopWindow = Arr::get($shop->settings ?? [], 'marketing.attribution_window_days');
+
+        if (is_numeric($shopWindow)) {
+            return (int) $shopWindow;
+        }
+
+        return (int) config('marketing.attribution_window_days', 90);
+    }
+}

--- a/app/Actions/CRM/TrafficSource/GetShopEmailMarketingPerformance.php
+++ b/app/Actions/CRM/TrafficSource/GetShopEmailMarketingPerformance.php
@@ -21,6 +21,7 @@ use Lorisleiva\Actions\Concerns\AsAction;
 class GetShopEmailMarketingPerformance
 {
     use AsAction;
+    use WithAttributionWindow;
 
     /**
      * Answers, per mailshot and in total, whether the emails a shop sends earn sales or just annoy
@@ -62,15 +63,22 @@ class GetShopEmailMarketingPerformance
 
         $campaignIds = $campaignByMailshot->values();
 
-        $customerTotals = DB::table('model_has_traffic_sources')
-            ->join('customer_stats', 'customer_stats.customer_id', '=', 'model_has_traffic_sources.model_id')
-            ->where('model_has_traffic_sources.model_type', 'Customer')
-            ->whereIn('model_has_traffic_sources.traffic_source_campaign_id', $campaignIds)
-            ->groupBy('model_has_traffic_sources.traffic_source_campaign_id')
+        $attributionWindow = GetAttributionWindow::run($shop);
+
+        $customerTotals = DB::table('invoices')
+            ->join('model_has_traffic_sources as p', function ($join) use ($attributionWindow) {
+                $join->on('p.model_id', '=', 'invoices.customer_id')
+                    ->where('p.model_type', '=', 'Customer');
+
+                $this->constrainToAttributionWindow($join, $attributionWindow);
+            })
+            ->whereIn('p.traffic_source_campaign_id', $campaignIds)
+            ->where('invoices.in_process', false)
+            ->groupBy('p.traffic_source_campaign_id')
             ->select(
-                'model_has_traffic_sources.traffic_source_campaign_id as campaign_id',
-                DB::raw('SUM(model_has_traffic_sources.share) as customers'),
-                DB::raw('SUM(customer_stats.sales_all * model_has_traffic_sources.share) as revenue'),
+                'p.traffic_source_campaign_id as campaign_id',
+                DB::raw('SUM(p.share) as customers'),
+                DB::raw('SUM(invoices.net_amount * p.share) as revenue'),
             )
             ->get()
             ->keyBy('campaign_id');

--- a/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
+++ b/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
@@ -17,6 +17,7 @@ use Lorisleiva\Actions\Concerns\AsAction;
 class GetShopMarketingOverview
 {
     use AsAction;
+    use WithAttributionWindow;
 
     /**
      * Assembles the marketing dashboard's numbers for a period: attributed revenue, ad spend, and the
@@ -42,7 +43,8 @@ class GetShopMarketingOverview
             ->get()
             ->keyBy('id');
 
-        $revenue       = $this->revenueBySource($shop, $from);
+        $window        = GetAttributionWindow::run($shop);
+        $revenue       = $this->revenueBySource($shop, $from, $window);
         $registrations = $this->registrationsBySource($shop, $from);
         $spend         = $this->spendBySource($shop, $from);
 
@@ -87,12 +89,19 @@ class GetShopMarketingOverview
         ];
     }
 
-    private function revenueBySource(Shop $shop, ?Carbon $from)
+    /**
+     * Revenue a channel may claim: invoiced after the touch that earned it, and no later than the
+     * attribution window allows. Without the first condition a click today collects a customer's
+     * entire history; without the second it collects their next several years.
+     */
+    private function revenueBySource(Shop $shop, ?Carbon $from, int $window)
     {
         return DB::table('invoices')
-            ->join('model_has_traffic_sources as p', function ($join) {
+            ->join('model_has_traffic_sources as p', function ($join) use ($window) {
                 $join->on('p.model_id', '=', 'invoices.customer_id')
                     ->where('p.model_type', '=', 'Customer');
+
+                $this->constrainToAttributionWindow($join, $window);
             })
             ->where('invoices.shop_id', $shop->id)
             ->where('invoices.in_process', false)
@@ -143,10 +152,14 @@ class GetShopMarketingOverview
      */
     private function campaigns(Shop $shop, ?Carbon $from, int $limit = 8): array
     {
+        $window = GetAttributionWindow::run($shop);
+
         $revenue = DB::table('invoices')
-            ->join('model_has_traffic_sources as p', function ($join) {
+            ->join('model_has_traffic_sources as p', function ($join) use ($window) {
                 $join->on('p.model_id', '=', 'invoices.customer_id')
                     ->where('p.model_type', '=', 'Customer');
+
+                $this->constrainToAttributionWindow($join, $window);
             })
             ->whereNotNull('p.traffic_source_campaign_id')
             ->where('invoices.shop_id', $shop->id)

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceCampaignHydrateStats.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceCampaignHydrateStats.php
@@ -8,6 +8,8 @@
 
 namespace App\Actions\CRM\TrafficSource\Hydrator;
 
+use App\Actions\CRM\TrafficSource\GetAttributionWindow;
+use App\Actions\CRM\TrafficSource\WithAttributionWindow;
 use App\Models\CRM\TrafficSourceCampaign;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\DB;
@@ -16,6 +18,7 @@ use Lorisleiva\Actions\Concerns\AsAction;
 class TrafficSourceCampaignHydrateStats implements ShouldBeUnique
 {
     use AsAction;
+    use WithAttributionWindow;
 
     public int $jobUniqueFor = 3600;
 
@@ -45,8 +48,22 @@ class TrafficSourceCampaignHydrateStats implements ShouldBeUnique
             ->select(
                 DB::raw('COALESCE(SUM(model_has_traffic_sources.share), 0) as customers'),
                 DB::raw('COALESCE(SUM(customer_stats.number_orders_state_dispatched * model_has_traffic_sources.share), 0) as purchases'),
-                DB::raw('COALESCE(SUM(customer_stats.sales_all * model_has_traffic_sources.share), 0) as revenue'),
-                DB::raw('COALESCE(SUM(customer_stats.sales_org_currency_all * model_has_traffic_sources.share), 0) as org_revenue'),
+            )
+            ->first();
+
+        $window  = GetAttributionWindow::run($campaign->trafficSource->shop);
+        $revenue = DB::table('invoices')
+            ->join('model_has_traffic_sources as p', function ($join) use ($window) {
+                $join->on('p.model_id', '=', 'invoices.customer_id')
+                    ->where('p.model_type', '=', 'Customer');
+
+                $this->constrainToAttributionWindow($join, $window);
+            })
+            ->where('p.traffic_source_campaign_id', $campaign->id)
+            ->where('invoices.in_process', false)
+            ->select(
+                DB::raw('COALESCE(SUM(invoices.net_amount * p.share), 0) as revenue'),
+                DB::raw('COALESCE(SUM(invoices.org_net_amount * p.share), 0) as org_revenue'),
             )
             ->first();
 
@@ -63,8 +80,8 @@ class TrafficSourceCampaignHydrateStats implements ShouldBeUnique
             [
                 'number_customers'           => $attribution->customers,
                 'number_customer_purchases'  => $attribution->purchases,
-                'total_customer_revenue'     => $attribution->revenue,
-                'org_total_customer_revenue' => $attribution->org_revenue,
+                'total_customer_revenue'     => $revenue->revenue,
+                'org_total_customer_revenue' => $revenue->org_revenue,
                 'total_cost'                 => $cost->total,
                 'org_total_cost'             => $cost->org_total,
             ]

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
@@ -13,6 +13,7 @@ namespace App\Actions\CRM\TrafficSource\Hydrator;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
+use App\Actions\CRM\TrafficSource\GetAttributionWindow;
 use App\Models\CRM\TrafficSource;
 
 class TrafficSourceHydrateCustomers implements ShouldBeUnique
@@ -33,20 +34,59 @@ class TrafficSourceHydrateCustomers implements ShouldBeUnique
      * here too: half a customer, half their orders, half their revenue to each. Summing any of these
      * figures across every traffic source of a shop therefore reproduces the shop's real totals —
      * channels share the credit, they never each claim the whole of it.
+     *
+     * Revenue is what the channel actually earned, not what its customers have ever spent: only
+     * invoices raised after a touch, and within the shop's attribution window, are counted. Before
+     * this, a customer registered in 2022 who clicked a newsletter yesterday handed that newsletter
+     * four years of prior trade, and the listing reported it as marketing performance.
      */
     public function handle(TrafficSource $trafficSource): void
     {
-        $totals = DB::table('model_has_traffic_sources')
+        $counts = DB::table('model_has_traffic_sources')
             ->join('customer_stats', 'customer_stats.customer_id', '=', 'model_has_traffic_sources.model_id')
             ->where('model_has_traffic_sources.traffic_source_id', $trafficSource->id)
             ->where('model_has_traffic_sources.model_type', 'Customer')
             ->select(
                 DB::raw('COALESCE(SUM(model_has_traffic_sources.share), 0) as customers'),
                 DB::raw('COALESCE(SUM(customer_stats.number_orders_state_dispatched * model_has_traffic_sources.share), 0) as purchases'),
-                DB::raw('COALESCE(SUM(customer_stats.sales_all * model_has_traffic_sources.share), 0) as revenue'),
-                DB::raw('COALESCE(SUM(customer_stats.sales_org_currency_all * model_has_traffic_sources.share), 0) as org_revenue'),
             )
             ->first();
+
+        $window = GetAttributionWindow::run($trafficSource->shop);
+
+        $revenue = DB::table('invoices')
+            ->join('model_has_traffic_sources as p', function ($join) use ($window) {
+                $join->on('p.model_id', '=', 'invoices.customer_id')
+                    ->where('p.model_type', '=', 'Customer');
+
+                $join->where(function ($q) use ($window) {
+                    $q->whereNull('p.first_touch_at')
+                        ->orWhere(function ($inWindow) use ($window) {
+                            $inWindow->whereColumn('invoices.date', '>=', 'p.first_touch_at');
+
+                            if ($window > 0) {
+                                $inWindow->whereRaw(
+                                    "invoices.date <= p.last_touch_at + (? || ' days')::interval",
+                                    [$window]
+                                );
+                            }
+                        });
+                });
+            })
+            ->where('p.traffic_source_id', $trafficSource->id)
+            ->where('invoices.in_process', false)
+            ->select(
+                DB::raw('COALESCE(SUM(invoices.net_amount * p.share), 0) as revenue'),
+                DB::raw('COALESCE(SUM(invoices.org_net_amount * p.share), 0) as org_revenue'),
+            )
+            ->first();
+
+        $totals = (object) [
+            'customers'   => $counts->customers,
+            'purchases'   => $counts->purchases,
+            'revenue'     => $revenue->revenue,
+            'org_revenue' => $revenue->org_revenue,
+        ];
 
         $trafficSource->stats()->updateOrCreate(
             ['traffic_source_id' => $trafficSource->id],

--- a/app/Actions/CRM/TrafficSource/WithAttributionWindow.php
+++ b/app/Actions/CRM/TrafficSource/WithAttributionWindow.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+/**
+ * One definition of which revenue a marketing touch may claim, shared by every place that answers
+ * that question: the dashboard, both stats hydrators, and the email performance panel. They used to
+ * be separate copies, and a channel's campaigns could then legitimately out-earn the channel itself.
+ *
+ * The `marketing_attributable_invoices` SQL view mirrors this rule for the reporting views; keep the
+ * two in step.
+ */
+trait WithAttributionWindow
+{
+    /**
+     * Revenue counts when it was invoiced after the touch that earned it, and no later than the
+     * window allows. Rows with no recorded touch date are legacy and are left in rather than
+     * silently dropped, so historic attribution does not vanish the day this ships.
+     *
+     * @param \Illuminate\Database\Query\JoinClause $join
+     */
+    protected function constrainToAttributionWindow($join, int $window, string $pivotAlias = 'p'): void
+    {
+        $join->where(function ($query) use ($window, $pivotAlias) {
+            $query->whereNull($pivotAlias.'.first_touch_at')
+                ->orWhere(function ($inWindow) use ($window, $pivotAlias) {
+                    $inWindow->whereColumn('invoices.date', '>=', $pivotAlias.'.first_touch_at');
+
+                    if ($window > 0) {
+                        $inWindow->whereRaw(
+                            "invoices.date <= {$pivotAlias}.last_touch_at + (? || ' days')::interval",
+                            [$window]
+                        );
+                    }
+                });
+        });
+    }
+}

--- a/app/Models/CRM/Customer.php
+++ b/app/Models/CRM/Customer.php
@@ -629,7 +629,7 @@ class Customer extends Model implements HasMedia, Auditable
     public function trafficSources(): MorphToMany
     {
         return $this->morphToMany(TrafficSource::class, 'model', 'model_has_traffic_sources')
-            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model'])
+            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model', 'first_touch_at', 'last_touch_at'])
             ->withTimestamps();
     }
 

--- a/app/Models/CRM/Prospect.php
+++ b/app/Models/CRM/Prospect.php
@@ -260,7 +260,7 @@ class Prospect extends Model implements Auditable
     public function trafficSources(): MorphToMany
     {
         return $this->morphToMany(TrafficSource::class, 'model', 'model_has_traffic_sources')
-            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model'])
+            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model', 'first_touch_at', 'last_touch_at'])
             ->withTimestamps();
     }
 

--- a/app/Models/CRM/TrafficSource.php
+++ b/app/Models/CRM/TrafficSource.php
@@ -73,14 +73,14 @@ class TrafficSource extends Model
     public function orders(): MorphToMany
     {
         return $this->morphedByMany(Order::class, 'model', 'model_has_traffic_sources')
-            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model'])
+            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model', 'first_touch_at', 'last_touch_at'])
             ->withTimestamps();
     }
 
     public function customers(): MorphToMany
     {
         return $this->morphedByMany(Customer::class, 'model', 'model_has_traffic_sources')
-            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model'])
+            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model', 'first_touch_at', 'last_touch_at'])
             ->withTimestamps();
     }
 

--- a/app/Models/Ordering/Order.php
+++ b/app/Models/Ordering/Order.php
@@ -538,7 +538,7 @@ class Order extends Model implements HasMedia, Auditable
     public function trafficSources(): MorphToMany
     {
         return $this->morphToMany(TrafficSource::class, 'model', 'model_has_traffic_sources')
-            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model'])
+            ->withPivot(['share', 'traffic_source_campaign_id', 'attribution_model', 'first_touch_at', 'last_touch_at'])
             ->withTimestamps();
     }
 

--- a/config/marketing.php
+++ b/config/marketing.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Attribution window
+    |--------------------------------------------------------------------------
+    |
+    | How many days after a marketing touch its revenue may still be credited to
+    | that channel. Without a window a click today claims a customer's entire
+    | purchase history, including years of trade that predate it.
+    |
+    | 90 days suits wholesale reorder cycles. Google Ads defaults to 30 for
+    | comparison. Override per shop with settings.marketing.attribution_window_days.
+    |
+    */
+
+    'attribution_window_days' => env('MARKETING_ATTRIBUTION_WINDOW_DAYS', 90),
+
+];

--- a/database/migrations/2026_08_07_140000_add_touch_dates_to_model_has_traffic_sources.php
+++ b/database/migrations/2026_08_07_140000_add_touch_dates_to_model_has_traffic_sources.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * When each touch actually happened, as opposed to when the pivot row was written. Without it a
+     * touch can be credited with revenue that predates it: a customer who registered in 2022 and
+     * clicked a newsletter yesterday was handing that newsletter four years of prior trade.
+     *
+     * The dates come from the touch history itself, so they survive recalculation and backfilling.
+     */
+    public function up(): void
+    {
+        Schema::table('model_has_traffic_sources', function (Blueprint $table) {
+            $table->timestampTz('first_touch_at')->nullable()->after('attribution_model');
+            $table->timestampTz('last_touch_at')->nullable()->after('first_touch_at');
+            $table->index('last_touch_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('model_has_traffic_sources', function (Blueprint $table) {
+            $table->dropIndex(['last_touch_at']);
+            $table->dropColumn(['first_touch_at', 'last_touch_at']);
+        });
+    }
+};

--- a/database/migrations/2026_08_07_150000_apply_attribution_window_to_marketing_views.php
+++ b/database/migrations/2026_08_07_150000_apply_attribution_window_to_marketing_views.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * The views must apply the same attribution window the dashboard does, or management's SQL and
+     * the screen disagree about the same question. Revenue counts only where it was invoiced after
+     * the touch and inside the window.
+     *
+     * The window is read per shop from settings, falling back to 90 days. A view cannot read Laravel
+     * config, so that default is duplicated here; if config/marketing.php changes, recreate these.
+     */
+    public function up(): void
+    {
+        DB::statement("
+            CREATE OR REPLACE VIEW marketing_attributable_invoices AS
+            SELECT i.id            AS invoice_id,
+                   i.shop_id,
+                   i.date::date    AS date,
+                   i.net_amount,
+                   p.traffic_source_id,
+                   p.traffic_source_campaign_id,
+                   p.share
+            FROM invoices i
+            JOIN model_has_traffic_sources p
+              ON p.model_id = i.customer_id AND p.model_type = 'Customer'
+            JOIN shops s ON s.id = i.shop_id
+            WHERE i.in_process = false
+              AND i.date IS NOT NULL
+              AND (
+                    p.first_touch_at IS NULL
+                 OR (
+                        i.date >= p.first_touch_at
+                    AND (
+                          COALESCE((s.settings->'marketing'->>'attribution_window_days')::int, 90) <= 0
+                       OR i.date <= p.last_touch_at
+                              + (COALESCE((s.settings->'marketing'->>'attribution_window_days')::int, 90) || ' days')::interval
+                    )
+                    )
+              )
+        ");
+
+        DB::statement("
+            CREATE OR REPLACE VIEW marketing_channel_daily AS
+            WITH spend AS (
+                SELECT shop_id, traffic_source_id, date::date AS date, SUM(amount) AS cost
+                FROM traffic_source_costs GROUP BY 1, 2, 3
+            ),
+            revenue AS (
+                SELECT shop_id, traffic_source_id, date,
+                       SUM(net_amount * share) AS revenue,
+                       SUM(share)              AS invoices
+                FROM marketing_attributable_invoices GROUP BY 1, 2, 3
+            ),
+            registrations AS (
+                SELECT c.shop_id, p.traffic_source_id, c.created_at::date AS date,
+                       SUM(p.share) AS registrations
+                FROM customers c
+                JOIN model_has_traffic_sources p
+                  ON p.model_id = c.id AND p.model_type = 'Customer'
+                GROUP BY 1, 2, 3
+            ),
+            grid AS (
+                SELECT shop_id, traffic_source_id, date FROM spend
+                UNION SELECT shop_id, traffic_source_id, date FROM revenue
+                UNION SELECT shop_id, traffic_source_id, date FROM registrations
+            )
+            SELECT g.date, g.shop_id, s.slug AS shop, ts.name AS channel, ts.type,
+                   COALESCE(sp.cost, 0)          AS cost,
+                   COALESCE(rv.revenue, 0)       AS revenue,
+                   COALESCE(rv.invoices, 0)      AS invoices,
+                   COALESCE(rg.registrations, 0) AS registrations
+            FROM grid g
+            JOIN shops s ON s.id = g.shop_id
+            JOIN traffic_sources ts ON ts.id = g.traffic_source_id
+            LEFT JOIN spend sp ON sp.shop_id = g.shop_id AND sp.traffic_source_id = g.traffic_source_id AND sp.date = g.date
+            LEFT JOIN revenue rv ON rv.shop_id = g.shop_id AND rv.traffic_source_id = g.traffic_source_id AND rv.date = g.date
+            LEFT JOIN registrations rg ON rg.shop_id = g.shop_id AND rg.traffic_source_id = g.traffic_source_id AND rg.date = g.date
+        ");
+
+        DB::statement("
+            CREATE OR REPLACE VIEW marketing_channel_performance AS
+            SELECT ts.id AS traffic_source_id, ts.shop_id, s.slug AS shop,
+                   ts.name AS channel, ts.type,
+                   COALESCE(st.number_customers, 0)          AS registrations,
+                   COALESCE(st.number_customer_purchases, 0)  AS orders,
+                   COALESCE(st.total_customer_revenue, 0)     AS revenue,
+                   COALESCE(st.total_cost, 0)                 AS cost,
+                   CASE WHEN COALESCE(st.total_cost, 0) > 0
+                        THEN ROUND(st.total_customer_revenue / st.total_cost, 2) END AS roas,
+                   CASE WHEN COALESCE(st.total_cost, 0) > 0 AND COALESCE(st.number_customers, 0) > 0
+                        THEN ROUND(st.total_cost / st.number_customers, 2) END AS cost_per_registration
+            FROM traffic_sources ts
+            JOIN shops s ON s.id = ts.shop_id
+            LEFT JOIN traffic_source_stats st ON st.traffic_source_id = ts.id
+        ");
+
+        DB::statement("
+            CREATE OR REPLACE VIEW marketing_mailshot_performance AS
+            SELECT
+                m.id                                                          AS mailshot_id,
+                m.shop_id,
+                s.slug                                                        AS shop,
+                m.subject,
+                m.type,
+                m.sent_at,
+                COALESCE(ms.number_dispatched_emails, 0)                      AS sent,
+                COALESCE(ms.number_dispatched_emails_state_opened, 0)
+                    + COALESCE(ms.number_dispatched_emails_state_clicked, 0)  AS opened,
+                COALESCE(ms.number_dispatched_emails_state_clicked, 0)        AS clicked,
+                COALESCE(ms.number_dispatched_emails_state_unsubscribed, 0)   AS unsubscribed,
+                COALESCE(attr.customers, 0)                                   AS attributed_customers,
+                COALESCE(attr.revenue, 0)                                     AS attributed_revenue,
+                COALESCE(reg.registered, 0)                                   AS prospects_registered
+            FROM mailshots m
+            JOIN shops s ON s.id = m.shop_id
+            LEFT JOIN mailshot_stats ms ON ms.mailshot_id = m.id
+            LEFT JOIN traffic_source_campaigns c ON c.reference = 'mailshot-' || m.id::text
+            LEFT JOIN LATERAL (
+                SELECT SUM(ai.share)                   AS customers,
+                       SUM(ai.net_amount * ai.share)   AS revenue
+                FROM marketing_attributable_invoices ai
+                WHERE ai.traffic_source_campaign_id = c.id
+            ) attr ON true
+            LEFT JOIN LATERAL (
+                SELECT COUNT(*) AS registered
+                FROM model_has_traffic_sources p
+                JOIN prospects pr ON pr.id = p.model_id
+                WHERE p.model_type = 'Prospect'
+                  AND p.traffic_source_campaign_id = c.id
+                  AND pr.customer_id IS NOT NULL
+            ) reg ON true
+            WHERE m.type IN ('newsletter', 'marketing', 'invite')
+        ");
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP VIEW IF EXISTS marketing_channel_daily');
+        DB::statement('DROP VIEW IF EXISTS marketing_attributable_invoices');
+    }
+};

--- a/tests/Feature/CRM/AttributionWindowTest.php
+++ b/tests/Feature/CRM/AttributionWindowTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\CRM\TrafficSource\GetAttributionWindow;
+use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
+use App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution;
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+    config()->set('marketing.attribution_window_days', 90);
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->googleAds = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+    $this->customer  = createCustomer($this->shop);
+
+    $this->customer->trafficSources()->detach();
+    DB::table('invoices')->where('customer_id', $this->customer->id)->delete();
+
+    // One touch, 10 days ago.
+    $this->touchedAt = now()->subDays(10);
+    $this->customer->update(['traffic_sources' => $this->touchedAt->timestamp.'b']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+});
+
+function windowInvoice(string $date, float $net, $customer, $shop): void
+{
+    DB::table('invoices')->insert([
+        'group_id'        => $shop->group_id,
+        'organisation_id' => $shop->organisation_id,
+        'shop_id'         => $shop->id,
+        'customer_id'     => $customer->id,
+        'currency_id'     => $shop->currency_id,
+        'tax_category_id' => App\Models\Helpers\TaxCategory::firstOrFail()->id,
+        'reference'       => 'INV-'.uniqid(),
+        'slug'            => 'inv-'.uniqid(),
+        'type'            => 'invoice',
+        'net_amount'      => $net,
+        'total_amount'    => $net,
+        'in_process'      => false,
+        'payment_data'    => '{}',
+        'data'            => '{}',
+        'date'            => $date,
+        'created_at'      => $date,
+        'updated_at'      => $date,
+    ]);
+}
+
+it('records when each touch happened', function () {
+    $pivot = $this->customer->trafficSources()->first()->pivot;
+
+    expect($pivot->first_touch_at)->not->toBeNull();
+    expect(substr((string) $pivot->first_touch_at, 0, 10))->toBe($this->touchedAt->toDateString());
+});
+
+it('ignores revenue invoiced before the touch', function () {
+    windowInvoice(now()->subDays(400)->toDateTimeString(), 5000, $this->customer, $this->shop);
+    windowInvoice(now()->subDays(2)->toDateTimeString(), 300, $this->customer, $this->shop);
+
+    $overview = GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::ALL_TIME);
+
+    // Only the invoice raised after the click counts; the 5,000 predates it.
+    expect($overview['totals']['revenue'])->toBe(300.0);
+});
+
+it('ignores revenue invoiced after the window closes', function () {
+    // Touch was 10 days ago, so a 5-day window has already expired.
+    config()->set('marketing.attribution_window_days', 5);
+
+    windowInvoice(now()->subDays(2)->toDateTimeString(), 300, $this->customer, $this->shop);
+
+    expect(GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::ALL_TIME)['totals']['revenue'])
+        ->toBe(0.0);
+});
+
+it('counts revenue inside the window', function () {
+    config()->set('marketing.attribution_window_days', 90);
+
+    windowInvoice(now()->subDays(2)->toDateTimeString(), 300, $this->customer, $this->shop);
+
+    expect(GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::ALL_TIME)['totals']['revenue'])
+        ->toBe(300.0);
+});
+
+it('lets a shop override the group window', function () {
+    expect(GetAttributionWindow::run($this->shop))->toBe(90);
+
+    $this->shop->update(['settings' => array_merge($this->shop->settings ?? [], [
+        'marketing' => ['attribution_window_days' => 30],
+    ])]);
+
+    expect(GetAttributionWindow::run($this->shop->fresh()))->toBe(30);
+});
+
+it('disables the window when it is set to zero', function () {
+    config()->set('marketing.attribution_window_days', 0);
+
+    windowInvoice(now()->subDays(400)->toDateTimeString(), 5000, $this->customer, $this->shop);
+    windowInvoice(now()->subDays(2)->toDateTimeString(), 300, $this->customer, $this->shop);
+
+    // Causality still applies: the pre-touch invoice never counts, window or no window.
+    expect(GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::ALL_TIME)['totals']['revenue'])
+        ->toBe(300.0);
+});

--- a/tests/Feature/CRM/EmailMarketingPerformanceTest.php
+++ b/tests/Feature/CRM/EmailMarketingPerformanceTest.php
@@ -14,7 +14,6 @@ use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
 use App\Actions\CRM\TrafficSource\RecordEmailClickTouchpoint;
 use App\Enums\Comms\Outbox\OutboxCodeEnum;
 use App\Models\Comms\Mailshot;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 
@@ -40,6 +39,9 @@ beforeEach(function () {
     $this->customer->update(['traffic_sources' => null]);
     $this->customer->trafficSources()->detach();
 
+    // Shared fixtures: clear invoices so revenue assertions do not accumulate across tests.
+    DB::table('invoices')->where('customer_id', $this->customer->id)->delete();
+
     $this->googleAds  = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
     $this->newsletter = createTrafficSource($this->shop, 'newsletter', 'Newsletter');
 });
@@ -60,13 +62,13 @@ it('returns empty performance for a shop that has sent nothing', function () {
 });
 
 it('splits customer credit between channels so their stats sum to the real totals', function () {
-    $this->customer->update(['traffic_sources' => '1700000000b']);
+    $this->customer->update(['traffic_sources' => now()->subDays(11)->timestamp.'b']);
     \App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution::run($this->customer->fresh());
 
-    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'));
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), now()->subDays(10));
 
+    createInvoiceFor($this->customer, $this->shop, now()->subDay()->toDateTimeString(), 1000);
     DB::table('customer_stats')->where('customer_id', $this->customer->id)->update([
-        'sales_all'                      => 1000,
         'number_orders_state_dispatched' => 4,
     ]);
 
@@ -96,9 +98,9 @@ it('reports engagement, estimated cost and attributed revenue per mailshot', fun
         'number_dispatched_emails_state_unsubscribed' => 7,
     ]);
 
-    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), now()->subDays(10), $mailshot);
 
-    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update(['sales_all' => 250]);
+    createInvoiceFor($this->customer, $this->shop, now()->subDay()->toDateTimeString(), 250);
 
     $performance = GetShopEmailMarketingPerformance::run($this->shop);
 
@@ -121,10 +123,10 @@ it('attributes only the newsletter share of a customer other channels also touch
     $mailshot = makeMailshot($this->shop);
     $mailshot->stats()->update(['number_dispatched_emails' => 100]);
 
-    $this->customer->update(['traffic_sources' => '1700000000b']);
-    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+    $this->customer->update(['traffic_sources' => now()->subDays(11)->timestamp.'b']);
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), now()->subDays(10), $mailshot);
 
-    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update(['sales_all' => 1000]);
+    createInvoiceFor($this->customer, $this->shop, now()->subDay()->toDateTimeString(), 1000);
 
     $performance = GetShopEmailMarketingPerformance::run($this->shop);
 
@@ -145,7 +147,7 @@ it('credits the mailshot channel with the registration when a prospect converts'
         ])
     );
 
-    RecordEmailClickTouchpoint::run($prospect, Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+    RecordEmailClickTouchpoint::run($prospect, now()->subDays(10), $mailshot);
 
     $customer = \App\Actions\CRM\Customer\StoreCustomer::make()->action(
         $this->shop,
@@ -173,10 +175,10 @@ it('serves honest share-weighted numbers through the sql views', function () {
     $mailshot = makeMailshot($this->shop);
     $mailshot->stats()->update(['number_dispatched_emails' => 100]);
 
-    $this->customer->update(['traffic_sources' => '1700000000b']);
-    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+    $this->customer->update(['traffic_sources' => now()->subDays(11)->timestamp.'b']);
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), now()->subDays(10), $mailshot);
 
-    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update(['sales_all' => 1000]);
+    createInvoiceFor($this->customer, $this->shop, now()->subDay()->toDateTimeString(), 1000);
     TrafficSourceHydrateCustomers::run($this->googleAds);
     TrafficSourceHydrateCustomers::run($this->newsletter);
 
@@ -236,10 +238,10 @@ it('keeps repeat clickers visible to every mailshot they clicked', function () {
     $first->stats()->update(['number_dispatched_emails' => 10]);
     $second->stats()->update(['number_dispatched_emails' => 10]);
 
-    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-01 10:00:00'), $first);
-    RecordEmailClickTouchpoint::run($this->customer->fresh(), Carbon::parse('2026-01-02 10:00:00'), $second);
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), now()->subDays(10), $first);
+    RecordEmailClickTouchpoint::run($this->customer->fresh(), now()->subDays(9), $second);
 
-    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update(['sales_all' => 1000]);
+    createInvoiceFor($this->customer, $this->shop, now()->subDay()->toDateTimeString(), 1000);
 
     $performance = collect(GetShopEmailMarketingPerformance::run($this->shop)['mailshots'])->keyBy('id');
 
@@ -257,7 +259,7 @@ it('counts prospects who clicked a mailshot and later registered', function () {
         \App\Models\CRM\Prospect::factory()->definition()
     );
 
-    RecordEmailClickTouchpoint::run($prospect, Carbon::parse('2026-01-01 10:00:00'), $mailshot);
+    RecordEmailClickTouchpoint::run($prospect, now()->subDays(10), $mailshot);
 
     $performance = GetShopEmailMarketingPerformance::run($this->shop);
     expect($performance['mailshots'][0]['prospects_registered'])->toBe(0);

--- a/tests/Feature/CRM/MarketingPeriodTest.php
+++ b/tests/Feature/CRM/MarketingPeriodTest.php
@@ -34,7 +34,10 @@ beforeEach(function () {
     $this->customer  = createCustomer($this->shop);
 
     $this->customer->trafficSources()->detach();
-    $this->customer->update(['traffic_sources' => '1700000000b']);
+    // Touch 70 days ago: old enough to precede the fixtures' invoices, recent enough that they
+    // fall inside the 90-day attribution window.
+    $this->touchedAt = now()->subDays(70);
+    $this->customer->update(['traffic_sources' => $this->touchedAt->timestamp.'b']);
     RecalculateTrafficSourceAttribution::run($this->customer->fresh());
 
     TrafficSourceCost::where('shop_id', $this->shop->id)->delete();
@@ -87,11 +90,13 @@ it('counts only revenue and spend inside the selected period', function () {
 
     $allTime = GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::ALL_TIME);
 
+    // The -60d invoice postdates the touch and is inside the window, so all-time sees both.
     expect($allTime['totals']['revenue'])->toBe(1400.0);
     expect($allTime['totals']['spend'])->toBe(600.0);
 });
 
 it('reproduces the lifetime stats figure when the period is all time', function () {
+    // The 200-day-old invoice predates the touch, so neither the dashboard nor the rollup counts it.
     invoiceOn(now()->subDays(200)->toDateTimeString(), 250, $this->customer, $this->shop);
     invoiceOn(now()->subDay()->toDateTimeString(), 750, $this->customer, $this->shop);
 
@@ -108,7 +113,7 @@ it('reproduces the lifetime stats figure when the period is all time', function 
 it('splits period revenue between channels by their shares', function () {
     $organic = createTrafficSource($this->shop, 'organic-google', 'Organic Google');
 
-    $this->customer->update(['traffic_sources' => '1700000000b|1700000100a']);
+    $this->customer->update(['traffic_sources' => $this->touchedAt->timestamp.'b|'.$this->touchedAt->addSecond()->timestamp.'a']);
     RecalculateTrafficSourceAttribution::run($this->customer->fresh());
 
     invoiceOn(now()->subDay()->toDateTimeString(), 1000, $this->customer, $this->shop);

--- a/tests/Feature/CRM/TrafficSourceCampaignStatsTest.php
+++ b/tests/Feature/CRM/TrafficSourceCampaignStatsTest.php
@@ -52,12 +52,12 @@ it('rolls a campaign\'s attributed customers and revenue into its own stats', fu
     $customer = StoreCustomer::make()->action(
         $this->shop,
         array_merge(Customer::factory()->definition(), [
-            'traffic_sources' => '1700000000b'.$reference,
+            'traffic_sources' => now()->subDays(10)->timestamp.'b'.$reference,
         ])
     );
 
+    createInvoiceFor($customer, $this->shop, now()->subDay()->toDateTimeString(), 900);
     DB::table('customer_stats')->where('customer_id', $customer->id)->update([
-        'sales_all'                      => 900,
         'number_orders_state_dispatched' => 3,
     ]);
 
@@ -111,11 +111,11 @@ it('never lets a source\'s campaigns claim more than the source itself', functio
     $customer = StoreCustomer::make()->action(
         $this->shop,
         array_merge(Customer::factory()->definition(), [
-            'traffic_sources' => '1700000000b'.$first.'|1700000100b'.$second,
+            'traffic_sources' => now()->subDays(10)->timestamp.'b'.$first.'|'.now()->subDays(9)->timestamp.'b'.$second,
         ])
     );
 
-    DB::table('customer_stats')->where('customer_id', $customer->id)->update(['sales_all' => 1000]);
+    createInvoiceFor($customer, $this->shop, now()->subDay()->toDateTimeString(), 1000);
 
     TrafficSourceHydrateCustomers::run($this->googleAds);
 
@@ -156,31 +156,13 @@ it('reports campaign performance for the selected period on the dashboard', func
     $customer = StoreCustomer::make()->action(
         $this->shop,
         array_merge(Customer::factory()->definition(), [
-            'traffic_sources' => '1700000000b'.$reference,
+            'traffic_sources' => now()->subDays(10)->timestamp.'b'.$reference,
         ])
     );
 
     $campaign = TrafficSourceCampaign::where('reference', $reference)->firstOrFail();
 
-    DB::table('invoices')->insert([
-        'group_id'        => $this->shop->group_id,
-        'organisation_id' => $this->shop->organisation_id,
-        'shop_id'         => $this->shop->id,
-        'customer_id'     => $customer->id,
-        'currency_id'     => $this->shop->currency_id,
-        'tax_category_id' => App\Models\Helpers\TaxCategory::firstOrFail()->id,
-        'reference'       => 'INV-'.uniqid(),
-        'slug'            => 'inv-'.uniqid(),
-        'type'            => 'invoice',
-        'net_amount'      => 400,
-        'total_amount'    => 400,
-        'in_process'      => false,
-        'payment_data'    => '{}',
-        'data'            => '{}',
-        'date'            => now()->subDay()->toDateTimeString(),
-        'created_at'      => now()->subDay()->toDateTimeString(),
-        'updated_at'      => now()->subDay()->toDateTimeString(),
-    ]);
+    createInvoiceFor($customer, $this->shop, now()->subDay()->toDateTimeString(), 400);
 
     StoreTrafficSourceCost::run($this->googleAds, [
         'date'                       => now()->subDay()->toDateString(),

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -242,6 +242,34 @@ function createCustomer(Shop $shop): Customer
     return $customer;
 }
 
+/**
+ * Marketing revenue is measured from invoices, so tests that assert on attributed revenue need real
+ * ones rather than a hand-set customer_stats rollup.
+ */
+function createInvoiceFor($customer, $shop, string $date, float $net, bool $inProcess = false): void
+{
+    \Illuminate\Support\Facades\DB::table('invoices')->insert([
+        'group_id'        => $shop->group_id,
+        'organisation_id' => $shop->organisation_id,
+        'shop_id'         => $shop->id,
+        'customer_id'     => $customer->id,
+        'currency_id'     => $shop->currency_id,
+        'tax_category_id' => \App\Models\Helpers\TaxCategory::firstOrFail()->id,
+        'reference'       => 'INV-'.uniqid(),
+        'slug'            => 'inv-'.uniqid(),
+        'type'            => 'invoice',
+        'net_amount'      => $net,
+        'org_net_amount'  => $net,
+        'total_amount'    => $net,
+        'in_process'      => $inProcess,
+        'payment_data'    => '{}',
+        'data'            => '{}',
+        'date'            => $date,
+        'created_at'      => $date,
+        'updated_at'      => $date,
+    ]);
+}
+
 function createTrafficSource(Shop $shop, string $type, string $name): TrafficSource
 {
     return TrafficSource::firstOrCreate(


### PR DESCRIPTION
Fixes the problem you spotted on the traffic sources listing: **Organic Google showing 2 registrations but €22,911 revenue.**

## What was wrong

Revenue was being credited to touches that came *after* it. Concretely, from production:

| customer | registered | first touch | lifetime revenue |
|---|---|---|---|
| 183414 | **2022-06-08** | 2026-08-06 | €22,410 |
| 254726 | **2024-05-26** | 2026-08-06 | €20,595 |

Every touch in the system is days old, so **essentially 100% of that revenue predated the click claiming it**. Not a rounding problem — a channel was being credited with years of trade it had nothing to do with.

## Two rules

**Causality** — revenue must be invoiced *after* the touch. Not a tuning choice.

**Window** — and within N days of it. Defaults to **90** (wholesale reorder cycles; Google Ads uses 30 for comparison), overridable per shop via `settings.marketing.attribution_window_days` because a dropshipping shop converts in days. `0` disables the window; causality still applies.

## Touch dates had to be recorded first

The pivot only had `created_at` — when the row was *written*, not when the visitor arrived. Added `first_touch_at` / `last_touch_at`, populated from the touch history itself so they survive recalculation and backfills.

## One definition, not five

The rule lives in `WithAttributionWindow`, shared by the dashboard, both stats hydrators and the email panel. Separate copies would let a channel's campaigns out-earn the channel — which is exactly what happened mid-development and the tests caught. The SQL views mirror it via a new `marketing_attributable_invoices` view, so management's queries and the screen agree.

## Consequence worth stating plainly

**Rollup revenue changes meaning** — from *"what this channel's customers have ever spent"* to *"what this channel earned"*. Numbers on the traffic sources listing will drop sharply after deploy. That is the correction, not a regression.

Pivot rows with no recorded touch date are left alone rather than dropped, so historic attribution survives the deploy.

## Tests

6 new: touch dates recorded, pre-touch revenue ignored, post-window revenue ignored, in-window revenue counted, per-shop override, window disabled.

Full sweep green: 6 window + 6 period + 6 campaign + 9 cost + 8 attribution + 10 email + 41 touchpoint/unit.