### PR TITLE
🩺 Marketing attribution: data-quality view + remove dead attribution paths

### DIFF
--- a/app/Actions/CRM/TrafficSource/GetShopAttributionDataQuality.php
+++ b/app/Actions/CRM/TrafficSource/GetShopAttributionDataQuality.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+use App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum;
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
+use App\Models\Catalogue\Shop;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetShopAttributionDataQuality
+{
+    use AsAction;
+
+    public const STATUS_OK      = 'ok';
+    public const STATUS_WARNING = 'warning';
+    public const STATUS_ERROR   = 'error';
+
+    /**
+     * Attribution fails quietly: a broken capture script, an unseeded channel or a campaign reference
+     * nothing matches all show up as smaller numbers rather than as errors. These checks make each of
+     * those failures visible on its own, per shop.
+     *
+     * @return array{period: string, period_label: string, from: string|null, checks: array<int, array{key: string, label: string, status: string, value: string, hint: string, items: array<int, string>}>}
+     */
+    public function handle(Shop $shop, MarketingPeriodEnum $period = MarketingPeriodEnum::LAST_30): array
+    {
+        $from = $period->startsAt();
+
+        return [
+            'period'       => $period->value,
+            'period_label' => MarketingPeriodEnum::labels()[$period->value],
+            'from'         => $from?->toDateString(),
+            'checks'       => [
+                $this->registrationsWithoutAttribution($shop, $from),
+                $this->sharesNotSummingToOne($shop),
+                $this->missingTrafficSources($shop),
+                $this->neverCreditedTrafficSources($shop),
+                $this->unmatchedCampaignReferences($shop, $from),
+            ],
+        ];
+    }
+
+    /**
+     * The single best signal that capture has broken: customers who registered without a single touch
+     * recorded. A shop always has some, since direct and untracked arrivals are real, so this reads as
+     * a proportion rather than a count, and only a high one is an alarm.
+     */
+    private function registrationsWithoutAttribution(Shop $shop, ?Carbon $from): array
+    {
+        $registrations = DB::table('customers')
+            ->where('shop_id', $shop->id)
+            ->when($from, fn ($query) => $query->where('created_at', '>=', $from))
+            ->count();
+
+        $unattributed = DB::table('customers')
+            ->where('shop_id', $shop->id)
+            ->when($from, fn ($query) => $query->where('created_at', '>=', $from))
+            ->whereNotExists(fn ($query) => $query
+                ->select(DB::raw(1))
+                ->from('model_has_traffic_sources as p')
+                ->whereColumn('p.model_id', 'customers.id')
+                ->where('p.model_type', 'Customer'))
+            ->count();
+
+        $percentage = $registrations > 0 ? round($unattributed / $registrations * 100, 1) : 0.0;
+
+        return [
+            'key'    => 'registrations_without_attribution',
+            'label'  => __('Registrations with no attribution'),
+            'status' => match (true) {
+                $registrations === 0 => self::STATUS_OK,
+                $percentage >= 90    => self::STATUS_ERROR,
+                $percentage >= 60    => self::STATUS_WARNING,
+                default              => self::STATUS_OK,
+            },
+            'value'  => $registrations > 0
+                ? $unattributed.' / '.$registrations.' ('.$percentage.'%)'
+                : __('No registrations in this period'),
+            'hint'   => __('Some untracked arrivals are normal. A sudden jump means the capture script or the touch cookie has stopped working.'),
+            'items'  => [],
+        ];
+    }
+
+    /**
+     * Every customer's shares must total exactly 1.00; anything else means attribution was written
+     * twice, or partially. This is the invariant, so a single offender is already an error.
+     */
+    private function sharesNotSummingToOne(Shop $shop): array
+    {
+        $offenders = DB::table('model_has_traffic_sources as p')
+            ->join('customers', 'customers.id', '=', 'p.model_id')
+            ->where('p.model_type', 'Customer')
+            ->where('customers.shop_id', $shop->id)
+            ->groupBy('customers.id', 'customers.name')
+            ->havingRaw('round(sum(p.share)::numeric, 2) <> 1.00')
+            ->select('customers.id', 'customers.name', DB::raw('round(sum(p.share)::numeric, 2) as total'))
+            /* ponytail: the invariant says this is empty, so the query is capped rather than counted
+               in full; if it ever is not empty the first offenders are enough to find the cause. */
+            ->limit(21)
+            ->get();
+
+        return [
+            'key'    => 'shares_not_summing_to_one',
+            'label'  => __('Customers whose shares do not sum to 1.00'),
+            'status' => $offenders->isEmpty() ? self::STATUS_OK : self::STATUS_ERROR,
+            'value'  => match (true) {
+                $offenders->isEmpty()    => __('None'),
+                $offenders->count() > 20 => '20+',
+                default                  => (string) $offenders->count(),
+            },
+            'hint'   => __('Should always be zero. Rebuild the affected customers with traffic-source:recalculate-attribution.'),
+            'items'  => $offenders->take(20)->map(fn ($row) => '#'.$row->id.' '.$row->name.' = '.$row->total)->all(),
+        ];
+    }
+
+    /**
+     * A channel with no row in this shop discards every touch that names it, silently: newsletter went
+     * missing this way and a day of mailshot clicks was lost before anyone noticed.
+     */
+    private function missingTrafficSources(Shop $shop): array
+    {
+        $existing = DB::table('traffic_sources')->where('shop_id', $shop->id)->pluck('type')->all();
+        $missing  = array_diff(TrafficSourcesTypeEnum::values(), $existing);
+
+        return [
+            'key'    => 'missing_traffic_sources',
+            'label'  => __('Channels with no row in this shop'),
+            'status' => empty($missing) ? self::STATUS_OK : self::STATUS_ERROR,
+            'value'  => empty($missing) ? __('None') : (string) count($missing),
+            'hint'   => __('Touches naming these channels are discarded. Run traffic-source:seed.'),
+            'items'  => array_values(array_map(fn (string $type) => TrafficSourcesTypeEnum::labels()[$type], $missing)),
+        ];
+    }
+
+    /**
+     * A channel that exists but has never been credited a single customer. Expected for channels the
+     * shop does not use; suspicious for one it does.
+     */
+    private function neverCreditedTrafficSources(Shop $shop): array
+    {
+        $uncredited = DB::table('traffic_sources')
+            ->where('shop_id', $shop->id)
+            ->whereNotExists(fn ($query) => $query
+                ->select(DB::raw(1))
+                ->from('model_has_traffic_sources as p')
+                ->whereColumn('p.traffic_source_id', 'traffic_sources.id')
+                ->where('p.model_type', 'Customer'))
+            ->orderBy('name')
+            ->pluck('name');
+
+        return [
+            'key'    => 'never_credited_traffic_sources',
+            'label'  => __('Channels never credited a customer'),
+            'status' => $uncredited->isEmpty() ? self::STATUS_OK : self::STATUS_WARNING,
+            'value'  => $uncredited->isEmpty() ? __('None') : (string) $uncredited->count(),
+            'hint'   => __('Normal for channels this shop does not use. Worth checking for one it does.'),
+            'items'  => $uncredited->all(),
+        ];
+    }
+
+    /**
+     * Campaign references carried by touches that matched no campaign row. Those touches still credit
+     * their channel, but drop out of every per-campaign figure, so spend imported against the same
+     * reference has nothing to compare itself with.
+     */
+    private function unmatchedCampaignReferences(Shop $shop, ?Carbon $from): array
+    {
+        /* ponytail: campaign refs live inside the touch string, so they can only be found by parsing
+           it. All time would mean parsing every customer the shop ever had on a page load, so the scan
+           is bounded to 90 days when no period start is given. Move it to a scheduled job if a longer
+           reach is ever needed. */
+        $scanFrom  = $from ?? now()->subDays(90);
+        $sources   = DB::table('traffic_sources')->where('shop_id', $shop->id)->pluck('id', 'type');
+        $campaigns = DB::table('traffic_source_campaigns')
+            ->whereIn('traffic_source_id', $sources->values())
+            ->get()
+            ->map(fn ($campaign) => $campaign->traffic_source_id.'|'.$campaign->reference)
+            ->flip();
+
+        $unmatched = [];
+
+        DB::table('customers')
+            ->where('shop_id', $shop->id)
+            ->where('created_at', '>=', $scanFrom)
+            ->whereNotNull('traffic_sources')
+            ->where('traffic_sources', '!=', '')
+            ->select('id', 'traffic_sources')
+            ->orderBy('id')
+            ->chunk(1000, function ($customers) use (&$unmatched, $sources, $campaigns) {
+                foreach ($customers as $customer) {
+                    foreach (ParseTrafficSourceTouches::run($customer->traffic_sources) as $touch) {
+                        if ($touch['campaign_ref'] === null) {
+                            continue;
+                        }
+
+                        $sourceId = $sources[$touch['type']->value] ?? null;
+
+                        if ($sourceId === null || $campaigns->has($sourceId.'|'.$touch['campaign_ref'])) {
+                            continue;
+                        }
+
+                        $key             = TrafficSourcesTypeEnum::labels()[$touch['type']->value].': '.$touch['campaign_ref'];
+                        $unmatched[$key] = ($unmatched[$key] ?? 0) + 1;
+                    }
+                }
+            });
+
+        arsort($unmatched);
+        $top = array_slice($unmatched, 0, 20, true);
+
+        return [
+            'key'    => 'unmatched_campaign_references',
+            'label'  => __('Campaign references matching no campaign'),
+            'status' => empty($unmatched) ? self::STATUS_OK : self::STATUS_WARNING,
+            'value'  => empty($unmatched) ? __('None') : (string) count($unmatched),
+            'hint'   => __('These touches credit their channel but no campaign. Non numeric references are never auto created, so they need a campaign row before they can be reported on.'),
+            'items'  => array_map(
+                fn (string $key, int $count) => $key.' ('.$count.' '.__('touches').')',
+                array_keys($top),
+                array_values($top)
+            ),
+        ];
+    }
+}

--- a/app/Actions/CRM/TrafficSource/ProcessTrafficSourceShare.php
+++ b/app/Actions/CRM/TrafficSource/ProcessTrafficSourceShare.php
@@ -17,7 +17,6 @@ class ProcessTrafficSourceShare
 
     public const ATTRIBUTION_FIRST_TOUCH      = 'first_touch';
     public const ATTRIBUTION_LAST_TOUCH       = 'last_touch';
-    public const ATTRIBUTION_LAST_NON_DIRECT  = 'last_non_direct_touch';
     public const ATTRIBUTION_LAST_PAID_TOUCH  = 'last_paid_touch';
     public const ATTRIBUTION_LINEAR           = 'linear';
 
@@ -36,8 +35,7 @@ class ProcessTrafficSourceShare
 
         return match ($attributionModel) {
             self::ATTRIBUTION_FIRST_TOUCH     => $this->firstTouch($touches),
-            self::ATTRIBUTION_LAST_TOUCH,
-            self::ATTRIBUTION_LAST_NON_DIRECT => $this->lastTouch($touches),
+            self::ATTRIBUTION_LAST_TOUCH      => $this->lastTouch($touches),
             self::ATTRIBUTION_LAST_PAID_TOUCH => $this->lastPaidTouch($touches),
             default                            => $this->linear($touches),
         };
@@ -64,35 +62,6 @@ class ProcessTrafficSourceShare
         $firstKey      = $this->touchKey($touches[0]);
 
         return [$this->buildResult($lastPaidTouch, 1.0, $this->touchKey($lastPaidTouch) === $firstKey)];
-    }
-
-    /**
-     * Identifies which unique touches in a journey assisted the conversion without receiving the
-     * final credit under the given attribution model (i.e. every eligible touch except the one(s)
-     * that ended up with credit). Used to report assisted vs primary conversions/revenue.
-     *
-     * @param array<int, array{timestamp: int|null, abbr: string, type: TrafficSourcesTypeEnum, campaign_ref: string|null}> $touches
-     *
-     * @return array<int, array{type: TrafficSourcesTypeEnum, campaign_ref: string|null}>
-     */
-    public function assistingTouches(array $touches, string $attributionModel = self::ATTRIBUTION_LINEAR): array
-    {
-        $credited = collect($this->handle($touches, $attributionModel))
-            ->map(fn (array $share) => $this->touchKey(['type' => $share['type'], 'campaign_ref' => $share['campaign_ref']]))
-            ->all();
-
-        $assisting = [];
-
-        foreach ($this->uniqueTouches($touches) as $key => $touch) {
-            if (!in_array($key, $credited, true)) {
-                $assisting[] = [
-                    'type'         => $touch['type'],
-                    'campaign_ref' => $touch['campaign_ref'],
-                ];
-            }
-        }
-
-        return $assisting;
     }
 
     /**

--- a/app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php
+++ b/app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php
@@ -9,6 +9,7 @@
 namespace App\Actions\UI\Dropshipping\Marketing;
 
 use App\Actions\Catalogue\Shop\UI\ShowShop;
+use App\Actions\CRM\TrafficSource\GetShopAttributionDataQuality;
 use App\Actions\CRM\TrafficSource\GetShopEmailMarketingPerformance;
 use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
 use App\Actions\OrgAction;
@@ -99,6 +100,9 @@ class ShowMarketingDashboard extends OrgAction
                         ],
                     ]
                 ),
+                MarketingDashboardTabsEnum::DATA_QUALITY->value => $this->tab == MarketingDashboardTabsEnum::DATA_QUALITY->value
+                    ? fn () => GetShopAttributionDataQuality::run($this->shop, $this->period)
+                    : Inertia::optional(fn () => GetShopAttributionDataQuality::run($this->shop, $this->period)),
                 'dashboard_stats'   => [
                     [
                         'name' => __('Newsletters'),

--- a/app/Console/Commands/RecalculateTrafficSourceAttributionCommand.php
+++ b/app/Console/Commands/RecalculateTrafficSourceAttributionCommand.php
@@ -23,7 +23,7 @@ class RecalculateTrafficSourceAttributionCommand extends Command
      */
     protected $signature = 'traffic-source:recalculate-attribution
                            {--shop= : Only recalculate for a specific shop slug}
-                           {--model=linear : Attribution model: first_touch, last_touch, last_non_direct_touch, last_paid_touch, linear}
+                           {--model=linear : Attribution model: first_touch, last_touch, last_paid_touch, linear}
                            {--from= : Only records created on/after this date (Y-m-d)}
                            {--to= : Only records created on/before this date (Y-m-d)}
                            {--dry-run : Count records without making changes}';
@@ -37,7 +37,6 @@ class RecalculateTrafficSourceAttributionCommand extends Command
         if (!in_array($model, [
             ProcessTrafficSourceShare::ATTRIBUTION_FIRST_TOUCH,
             ProcessTrafficSourceShare::ATTRIBUTION_LAST_TOUCH,
-            ProcessTrafficSourceShare::ATTRIBUTION_LAST_NON_DIRECT,
             ProcessTrafficSourceShare::ATTRIBUTION_LAST_PAID_TOUCH,
             ProcessTrafficSourceShare::ATTRIBUTION_LINEAR,
         ], true)) {

--- a/app/Enums/UI/Marketing/MarketingDashboardTabsEnum.php
+++ b/app/Enums/UI/Marketing/MarketingDashboardTabsEnum.php
@@ -17,6 +17,7 @@ enum MarketingDashboardTabsEnum: string
     use HasTabs;
 
     case DASHBOARD = 'dashboard';
+    case DATA_QUALITY = 'data_quality';
 
     public function blueprint(): array
     {
@@ -24,6 +25,10 @@ enum MarketingDashboardTabsEnum: string
             MarketingDashboardTabsEnum::DASHBOARD => [
                 'title' => __('Dashboard'),
                 'icon'  => 'fal fa-tachometer-alt-fast',
+            ],
+            MarketingDashboardTabsEnum::DATA_QUALITY => [
+                'title' => __('Data quality'),
+                'icon'  => 'fal fa-heartbeat',
             ],
         };
     }

--- a/resources/js/Components/DataDisplay/AttributionDataQuality.vue
+++ b/resources/js/Components/DataDisplay/AttributionDataQuality.vue
@@ -1,0 +1,51 @@
+<!--
+  - Author: Raul Perusquia <raul@inikoo.com>
+  - Created: Fri, 07 Aug 2026
+  - Copyright (c) 2026, Raul A Perusquia Flores
+  -->
+
+<script setup lang="ts">
+import { trans } from 'laravel-vue-i18n'
+
+defineProps<{
+    data: {
+        period_label: string
+        from: string | null
+        checks: {
+            key: string
+            label: string
+            status: 'ok' | 'warning' | 'error'
+            value: string
+            hint: string
+            items: string[]
+        }[]
+    }
+}>()
+
+const dotClass = {
+    ok: 'bg-green-500',
+    warning: 'bg-amber-500',
+    error: 'bg-red-500',
+}
+</script>
+
+<template>
+    <div class="px-4 py-4 space-y-3">
+        <div class="text-xs text-gray-500">
+            {{ trans('Period') }}: {{ data.period_label }}
+        </div>
+
+        <div v-for="check in data.checks" :key="check.key"
+             class="border border-gray-200 rounded-md px-4 py-3">
+            <div class="flex items-center gap-x-2">
+                <span class="w-2 h-2 rounded-full shrink-0" :class="dotClass[check.status]" />
+                <span class="text-sm">{{ check.label }}</span>
+                <span class="ml-auto text-sm tabular-nums">{{ check.value }}</span>
+            </div>
+            <div class="mt-1 pl-4 text-xs text-gray-500">{{ check.hint }}</div>
+            <ul v-if="check.items.length" class="mt-2 pl-4 text-xs text-gray-600 space-y-0.5">
+                <li v-for="item in check.items" :key="item">{{ item }}</li>
+            </ul>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Grp/Org/Marketing/MarketingDashboard.vue
+++ b/resources/js/Pages/Grp/Org/Marketing/MarketingDashboard.vue
@@ -18,6 +18,7 @@ import { PageHeadingTypes } from '@/types/PageHeading'
 import { Tabs as TSTabs } from '@/types/Tabs'
 import SimpleBox from '@/Components/DataDisplay/SimpleBox.vue'
 import MarketingOverview from '@/Components/DataDisplay/MarketingOverview.vue'
+import AttributionDataQuality from '@/Components/DataDisplay/AttributionDataQuality.vue'
 
 const props = defineProps<{
     title: string,
@@ -29,6 +30,7 @@ const props = defineProps<{
         icon: string
     }[]
     marketing_overview: InstanceType<typeof MarketingOverview>['$props']['overview']
+    data_quality?: InstanceType<typeof AttributionDataQuality>['$props']['data']
 
 
 }>()
@@ -39,7 +41,8 @@ const handleTabUpdate = (tabSlug: string) => useTabChange(tabSlug, currentTab)
 const component = computed(() => {
 
     const components: Component = {
-        dashboard: {}
+        dashboard: {},
+        data_quality: AttributionDataQuality,
     }
 
     return components[currentTab.value]

--- a/tests/Feature/CRM/AttributionDataQualityTest.php
+++ b/tests/Feature/CRM/AttributionDataQualityTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\CRM\TrafficSource\GetShopAttributionDataQuality;
+use App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution;
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
+use App\Models\CRM\TrafficSource;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->googleAds = createTrafficSource($this->shop, 'google-ads', 'Google Ads');
+    $this->customer  = createCustomer($this->shop);
+    $this->customer->trafficSources()->detach();
+});
+
+function dataQualityCheck(string $key, $shop, MarketingPeriodEnum $period = MarketingPeriodEnum::LAST_30): array
+{
+    $checks = GetShopAttributionDataQuality::run($shop, $period)['checks'];
+
+    return collect($checks)->firstWhere('key', $key);
+}
+
+it('reports registrations with no attribution as a proportion', function () {
+    $this->customer->update(['traffic_sources' => now()->subDay()->timestamp.'b']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    $unattributed = createCustomer($this->shop);
+    $unattributed->trafficSources()->detach();
+
+    $check = dataQualityCheck('registrations_without_attribution', $this->shop);
+
+    $registrations = DB::table('customers')
+        ->where('shop_id', $this->shop->id)
+        ->where('created_at', '>=', now()->subDays(30)->startOfDay())
+        ->count();
+
+    expect($check['value'])->toContain('/ '.$registrations);
+});
+
+it('flags customers whose attribution shares do not sum to one', function () {
+    $this->customer->trafficSources()->attach($this->googleAds->id, ['share' => 0.5]);
+
+    $check = dataQualityCheck('shares_not_summing_to_one', $this->shop);
+
+    expect($check['status'])->toBe(GetShopAttributionDataQuality::STATUS_ERROR)
+        ->and($check['items'][0])->toContain('#'.$this->customer->id)
+        ->and($check['items'][0])->toContain('0.50');
+});
+
+it('passes the share invariant check for a correctly attributed customer', function () {
+    $this->customer->update(['traffic_sources' => now()->subDay()->timestamp.'b|'.now()->timestamp.'a']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    $check = dataQualityCheck('shares_not_summing_to_one', $this->shop);
+
+    expect($check['status'])->toBe(GetShopAttributionDataQuality::STATUS_OK)
+        ->and($check['items'])->toBe([]);
+});
+
+it('flags a channel with no traffic source row in the shop', function () {
+    TrafficSource::where('shop_id', $this->shop->id)->where('type', 'newsletter')->delete();
+
+    $check = dataQualityCheck('missing_traffic_sources', $this->shop);
+
+    expect($check['status'])->toBe(GetShopAttributionDataQuality::STATUS_ERROR)
+        ->and($check['items'])->toContain('Newsletter');
+});
+
+it('lists channels that have never been credited a customer', function () {
+    $this->customer->update(['traffic_sources' => now()->subDay()->timestamp.'b']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    $check = dataQualityCheck('never_credited_traffic_sources', $this->shop);
+
+    expect($check['items'])->not->toContain('Google Ads')
+        ->and($check['status'])->toBe(GetShopAttributionDataQuality::STATUS_WARNING);
+});
+
+it('flags campaign references that matched no campaign', function () {
+    $this->customer->update(['traffic_sources' => now()->subDay()->timestamp.'b'.'not-a-campaign']);
+
+    $check = dataQualityCheck('unmatched_campaign_references', $this->shop);
+
+    expect($check['status'])->toBe(GetShopAttributionDataQuality::STATUS_WARNING)
+        ->and($check['items'][0])->toContain('not-a-campaign');
+});
+
+it('does not flag a campaign reference that resolves to a campaign', function () {
+    $this->customer->update(['traffic_sources' => now()->subDay()->timestamp.'b'.'987654']);
+    RecalculateTrafficSourceAttribution::run($this->customer->fresh());
+
+    $check = dataQualityCheck('unmatched_campaign_references', $this->shop);
+
+    expect($check['status'])->toBe(GetShopAttributionDataQuality::STATUS_OK)
+        ->and($check['items'])->toBe([]);
+});

--- a/tests/Unit/Actions/CRM/TrafficSource/ProcessTrafficSourceShareTest.php
+++ b/tests/Unit/Actions/CRM/TrafficSource/ProcessTrafficSourceShareTest.php
@@ -112,29 +112,3 @@ it('returns no credit under the last paid touch model when the journey has no pa
 
     expect($shares)->toBe([]);
 });
-
-it('treats last non direct touch the same as last touch, since no direct touch concept currently exists', function () {
-    $touches = ParseTrafficSourceTouches::run('1700000000a|1700000100b');
-
-    $shares = ProcessTrafficSourceShare::run($touches, ProcessTrafficSourceShare::ATTRIBUTION_LAST_NON_DIRECT);
-
-    expect($shares)->toHaveCount(1);
-    expect($shares[0]['type'])->toBe(TrafficSourcesTypeEnum::GOOGLE_ADS);
-});
-
-it('identifies touches that assisted but did not receive final credit under the last touch model', function () {
-    $touches = ParseTrafficSourceTouches::run('1700000000a|1700000100b|1700000200f');
-
-    $assisting = ProcessTrafficSourceShare::make()->assistingTouches($touches, ProcessTrafficSourceShare::ATTRIBUTION_LAST_TOUCH);
-
-    expect($assisting)->toHaveCount(2);
-    expect(array_column($assisting, 'type'))->toEqual([TrafficSourcesTypeEnum::ORGANIC_GOOGLE, TrafficSourcesTypeEnum::GOOGLE_ADS]);
-});
-
-it('has no assisting touches under the linear model, since every touch already received credit', function () {
-    $touches = ParseTrafficSourceTouches::run('1700000000a|1700000100b|1700000200f');
-
-    $assisting = ProcessTrafficSourceShare::make()->assistingTouches($touches, ProcessTrafficSourceShare::ATTRIBUTION_LINEAR);
-
-    expect($assisting)->toBe([]);
-});


### PR DESCRIPTION
Tidy-up and hardening pass on marketing attribution (live in prod 7 Aug 2026). Three independent items.

## 1. Removed `last_non_direct_touch`

It was advertised as a distinct attribution model by `ProcessTrafficSourceShare` and by
`traffic-source:recalculate-attribution --model=`, but its `match` arm ran the identical code
as `last_touch` — there is no "direct" traffic concept to distinguish. Constant, match arm, CLI
option text, validation entry and its test are gone. The command now rejects the value.

## 2. Removed `assistingTouches()`

**Deleted rather than wired up.** It was written for assisted-conversion reporting that was never
built, and building that reporting is a product decision, not a tidy-up: it needs its own figures,
its own place on the dashboard and its own definition of what "assisted" means for revenue, not just
for touches. Keeping a public, tested method with no callers costs more than git history does.

## 3. Data-quality view

New tab `Data quality` on the shop marketing dashboard, backed by
`App\Actions\CRM\TrafficSource\GetShopAttributionDataQuality`. Five checks, each with a status,
a figure and the offending rows:

| Check | Status when |
|---|---|
| Registrations with no attribution (count and %) | error ≥90%, warning ≥60% |
| Customers whose shares ≠ 1.00 | error if any — this is the invariant |
| Channels with no `traffic_sources` row in the shop | error if any (this is how `newsletter` went missing and a day of mailshot clicks was discarded) |
| Channels never credited a customer | warning if any |
| Campaign references matching no campaign | warning if any |

Two deliberate bounds, both marked with `ponytail:` comments in the code:

- the shares check caps at 21 rows (`20+`) rather than counting a table that should return nothing;
- campaign references only exist inside the touch string, so the scan is bounded to 90 days when
  the period is *all time*, rather than parsing every customer the shop ever had on a page load.

The tab loads via `Inertia::optional`, so the dashboard tab pays nothing for it.

`WithAttributionWindow`, the attribution-window logic and the `marketing_*` SQL views are untouched.

## Tests

- `tests/Feature/CRM/AttributionDataQualityTest.php` — 7 tests, one per check plus the two
  passing cases (correct shares, resolvable campaign ref). All pass.
- `tests/Unit/.../ProcessTrafficSourceShareTest.php` — 11 remaining tests pass; the three covering
  the removed model and method are gone.

Run in a worktree off `origin/main` with a copied autoloader, verified resolving to the worktree path.
Not merged, not deployed.