### PR TITLE
📚 docs(marketing): marketing attribution documentation (phase 8)

### DIFF
--- a/docs/marketing-attribution/README.md
+++ b/docs/marketing-attribution/README.md
@@ -1,0 +1,28 @@
+# Marketing attribution
+
+Which marketing channel earned which sale, and what it cost to earn it. Live in production since
+7 August 2026.
+
+| Document | Audience |
+| --- | --- |
+| [reading-the-numbers.md](reading-the-numbers.md) | Marketing and management. What the figures mean, and why revenue looks low. |
+| [engineering.md](engineering.md) | Engineers. How it works, what to run, what not to break. |
+| [utm-campaign-naming.md](utm-campaign-naming.md) | Whoever builds ad links. The naming standard and its one hard constraint. |
+| [troubleshooting.md](troubleshooting.md) | Symptom → cause → fix, plus the rollback note. |
+
+Advertising spend is imported separately — see [../google-ads-cost-ingestion/README.md](../google-ads-cost-ingestion/README.md).
+
+## Where to look in the app
+
+- **Marketing dashboard** — `/org/{organisation}/shops/{shop}/marketing`. Period-scoped, defaults to the last 30 days.
+- **Traffic sources listing** — `/org/{organisation}/shops/{shop}/marketing/traffic-sources`. All-time.
+- **Customer journey** — the marketing tab of any customer page.
+
+## Status on 7 August 2026
+
+Verified against production on the day of writing:
+
+- 331 customers of 610,019 carry touch data. The system only records touches from the day it went live, so this grows forward and cannot be backfilled.
+- 39 campaigns: 1 Google Ads campaign id, 38 mailshots.
+- **0 rows of advertising spend imported.** Every ROAS and CAC therefore shows a dash. Nothing is wrong; nothing has been imported yet.
+- Attributed revenue is about €1,505 across four shop/channel pairs. That is the honest post-touch figure — see [reading-the-numbers.md](reading-the-numbers.md).

--- a/docs/marketing-attribution/engineering.md
+++ b/docs/marketing-attribution/engineering.md
@@ -1,0 +1,209 @@
+# How it works, and how to operate it
+
+For engineers. Everything below was checked against the code and against production on 7 August 2026.
+
+## The pipeline
+
+```
+visit  →  aiku_tsd cookie (touch string)
+             │
+             ├─ registration ──→ customers.traffic_sources  (raw touch history, source of truth)
+             ├─ login ────────→ device cookie merged into the customer's history
+             └─ mailshot click → touch appended server-side
+                                   │
+                                   ▼
+                       model_has_traffic_sources  (derived pivot: share per channel)
+                                   │
+                                   ▼
+              traffic_source_stats / traffic_source_campaign_stats  (derived rollups)
+                                   │
+                                   ▼
+                     dashboard, listings, marketing_* SQL views
+```
+
+**Only `customers.traffic_sources` is source data.** Everything downstream is derived and can be
+rebuilt.
+
+## The touch string
+
+`app/Actions/Iris/CaptureTrafficSource.php` writes the `aiku_tsd` cookie; 120-day lifetime, trimmed
+oldest-first when it approaches 3.9 KB. It is in the encrypt-cookies exclusion list
+(`app/Http/Middleware/EncryptCookies.php`) so it stays readable as plain text.
+
+Format — segments joined by `|` (a `,` also parses, for legacy values):
+
+```
+<unix_ts><abbr><campaign_ref?>
+1754563200b21723300927 | 1754649600a
+└─ timestamp ─┘│└ campaign ref ┘
+               └ channel abbreviation
+```
+
+The abbreviation map lives in `TrafficSourcesTypeEnum::abbr()` — `a` organic Google, `b` Google Ads,
+`c` organic Bing, `d` Bing Ads, `e` organic Meta, `f` Meta Ads, `g`/`h` Pinterest, `i`/`j` TikTok,
+`k`/`l` LinkedIn, `m`/`n` Twitter, `o` YouTube, **`p` newsletter**. Anything ending `-ads` is paid
+(`TrafficSourcesTypeEnum::isPaid()`).
+
+Parse with `ParseTrafficSourceTouches` — never by hand. A companion cookie `aiku_lts` holds the last
+touch and suppresses a repeat of the identical source.
+
+### Capture rules
+
+`GetTrafficSourceFromUrl` (paid, checked first):
+
+| Channel | Trigger | Campaign ref |
+| --- | --- | --- |
+| Google Ads | `gclid` present | `gad_campaignid` if present |
+| Meta Ads | `fbclid` **and** `utm_medium=paid` | `utm_campaign` |
+| Bing Ads | `msclkid` | none, deliberately |
+
+`msclkid` is unique per click; recording it as a campaign made every Bing click its own campaign and
+matched no cost row ever.
+
+`GetTrafficSourceFromRefererHeader` (organic fallback) matches the domain of `X-Original-Referer`, or
+of the referer, against a fixed list: google, bing, facebook/instagram/threads/messenger/whatsapp,
+youtube/youtu.be, linkedin, pinterest, tiktok, twitter/x. No match, no touch.
+
+Campaign refs are sanitised — `|`, `,` and whitespace become `-`, because either separator inside a
+ref shatters the cookie on parse.
+
+## The pivot
+
+`model_has_traffic_sources` is polymorphic over Customer / Prospect / Order, with `share`,
+`traffic_source_campaign_id`, `attribution_model`, `first_touch_at`, `last_touch_at`.
+
+Shares are assigned by `ProcessTrafficSourceShare` (default model: linear). **Invariant — every
+customer's shares sum to exactly 1.00.** Check it after any change:
+
+```sql
+WITH per_customer AS (
+  SELECT model_id, round(sum(share),2) AS t
+  FROM model_has_traffic_sources WHERE model_type='Customer' GROUP BY model_id
+) SELECT t, count(*) FROM per_customer GROUP BY t;
+```
+
+One row, `1.00`. On 7 Aug 2026 that was `1.00 | 331`.
+
+**Order pivots are not recalculable.** An order carries no touch history of its own — its attribution
+is a snapshot `ProcessOrderTrafficSource` takes from the customer at submission. There is nothing to
+rebuild it from, which is why `traffic-source:recalculate-attribution` handles customers only.
+
+### Campaign auto-creation is restricted to numeric references
+
+`AttachTrafficSourcesToModel` will only create a campaign row for a reference matching `^\d{1,20}$`.
+Touch strings come from a client-controlled cookie; without the restriction a visitor could mint
+unlimited campaign rows named whatever they liked. `mailshot-<id>` refs are created server-side by
+`RecordEmailClickTouchpoint` with a real name and bypass this path. `reference` is globally unique —
+a collision across shops leaves the touch with its channel-level share and no campaign breakdown, by
+design.
+
+## The attribution window — the one thing with two copies
+
+Revenue may be claimed by a touch only when it was **invoiced after** that touch and **within N days**
+of it. Default 90, `config/marketing.php`, per-shop override at
+`settings.marketing.attribution_window_days`. Zero or negative disables the window; causality still
+applies.
+
+It is enforced in two places that **must stay in step**:
+
+- `App\Actions\CRM\TrafficSource\WithAttributionWindow` (PHP) — dashboard, both hydrators, email panel.
+  Resolved per shop by `GetAttributionWindow`.
+- The `marketing_attributable_invoices` SQL view. A view cannot read Laravel config, so the 90-day
+  default is duplicated in the migration.
+
+They were separate copies once, and a channel's campaigns could then legitimately out-earn the
+channel itself. **If `config/marketing.php` changes, recreate the views.**
+
+Rows with a null `first_touch_at` are legacy and are deliberately left in rather than silently
+dropped.
+
+Revenue is measured from **invoices** (`net_amount`, `in_process = false`), matching how
+`customer_stats.sales_all` is built — not from orders.
+
+## SQL views
+
+Four, created by `2026_08_06_230000_create_marketing_performance_views.php`,
+`2026_08_07_100000_create_marketing_daily_view.php`, and rewritten by
+`2026_08_07_150000_apply_attribution_window_to_marketing_views.php`:
+
+| View | Purpose |
+| --- | --- |
+| `marketing_attributable_invoices` | The window rule, in SQL. Base for the others. |
+| `marketing_channel_daily` | Cost, revenue, invoices, registrations per shop/channel/day. |
+| `marketing_channel_performance` | All-time rollup with ROAS and cost per registration. |
+| `marketing_mailshot_performance` | Sent / opened / clicked / attributed revenue per mailshot. |
+
+> **Standing trap.** These views hold Postgres dependencies on the columns they reference. Any
+> migration altering `traffic_source_stats`, `mailshot_stats`, `customer_stats`, `invoices` or
+> `traffic_source_costs` **must drop and recreate them**, or it fails at deploy.
+
+## Commands
+
+```bash
+php artisan traffic-source:seed
+```
+Creates the per-shop channel row for every enum case, across all shops, and deletes rows whose type
+left the enum. **Mandatory after adding a `TrafficSourcesTypeEnum` case**, and for any new shop.
+
+```bash
+php artisan traffic-source:recalculate-attribution [--shop=slug] [--model=linear] [--from=Y-m-d] [--to=Y-m-d] [--dry-run]
+```
+Rebuilds customer pivot rows from raw touch history. Models: `first_touch`, `last_touch`,
+`last_non_direct_touch`, `last_paid_touch`, `linear`. Customers only.
+`--model=last_non_direct_touch` currently runs the same code path as `last_touch`.
+
+```bash
+php artisan traffic-source:hydrate-campaign-stats [--shop=slug]
+```
+Rebuilds the campaign stats rollup from attribution and spend.
+
+```bash
+php artisan traffic-source:import-costs <file.csv> [--dry-run]
+```
+Columns: `shop,source,campaign,date,amount,currency`.
+
+```bash
+php artisan traffic-source:cost-token <shop> "<name>"
+php artisan traffic-source:cost-token <shop> --list
+php artisan traffic-source:cost-token --revoke=<id>
+```
+Sanctum tokens issued against the Shop, so scoping is free and revocation is per holder. Consumed by
+`POST /webhooks/traffic-source-costs` (`ReceiveTrafficSourceCostWebhook`).
+
+## Queues
+
+| Job | Queue |
+| --- | --- |
+| `RecordEmailClickTouchpoint` | `ses-analytics` |
+| `SyncCustomerTrafficSourcesFromDevice` | `low-priority` |
+| `TrafficSourceHydrateCustomers` | `low-priority` |
+| `TrafficSourceCampaignHydrateStats` | `low-priority` |
+
+The hydrators refresh dashboard statistics and must never compete with order processing. Both are
+`ShouldBeUnique`, keyed on the traffic source / campaign id. After editing any of these, run
+`php artisan horizon:terminate` or workers keep running the old code.
+
+## Files worth knowing
+
+| Path | What |
+| --- | --- |
+| `app/Actions/Iris/CaptureTrafficSource.php` | Writes the cookie. |
+| `app/Actions/CRM/TrafficSource/` | Everything else in the domain. |
+| `app/Actions/Traits/HasIrisUserData.php` | Merges the device cookie into a logged-in customer. |
+| `app/Actions/Comms/EmailTrackingEvent/StoreEmailTrackingEvent.php` | Mailshot-click guard. |
+| `app/Actions/Ordering/Order/ProcessOrderTrafficSource.php` | Order-level snapshot. |
+| `app/Actions/CRM/Customer/UI/GetCustomerJourney.php` | The timeline. |
+| `app/Actions/UI/Dropshipping/Marketing/ShowMarketingDashboard.php` | Dashboard page. |
+| `app/Enums/UI/Marketing/MarketingPeriodEnum.php` | Period options; default `LAST_30`. |
+| `config/marketing.php` | The window default. |
+
+## Traps that have already cost a day each
+
+- `DispatchedEmail::mailshot()` is **dead** — its column was dropped in May 2025. Use `sentMailshot()`
+  (a `hasOneThrough` via `mailshot_recipients`). The dead relation silently discarded every mailshot
+  click for a day.
+- **Only mailshot clicks are touches.** Transactional email reaches the same `CLICKED` state; the
+  guard in `StoreEmailTrackingEvent` keeps it out. Removing it hands the newsletter channel a share
+  of every engaged customer's revenue.
+- Touch data cannot be backfilled. Nothing exists before 7 August 2026.
+- `assistingTouches()` exists and is tested but has no callers.

--- a/docs/marketing-attribution/reading-the-numbers.md
+++ b/docs/marketing-attribution/reading-the-numbers.md
@@ -1,0 +1,124 @@
+# Reading the numbers
+
+For marketing and management. No technical knowledge assumed.
+
+---
+
+## The two figures everyone asks about
+
+**ROAS — return on ad spend.** Revenue a channel earned, divided by what you spent on it. ROAS 4
+means every €1 of spend brought back €4 of sales. It is a ratio, not a profit: it says nothing about
+margin, returns, or the cost of the goods.
+
+**CAC — cost per acquired customer.** Spend divided by the number of new customer registrations that
+channel earned. It answers "what did it cost us to win one new account?"
+
+Both need spend. **No spend imported, no ROAS and no CAC — the screen shows a dash.** That is the
+current state of every shop: no advertising cost has been imported yet. A dash is not a zero and not
+a fault.
+
+## Two screens, two different questions
+
+| Screen | Question it answers | Time span |
+| --- | --- | --- |
+| Marketing dashboard | "How did we do lately?" | The selected period. **Defaults to the last 30 days.** |
+| Traffic sources listing | "What has this channel ever earned us?" | All time, always. |
+
+They will not match, and are not meant to. Choose "All time" on the dashboard's period selector if
+you want to compare them. The dashboard offers last 7 / 30 / 90 days, month to date, year to date,
+and all time.
+
+---
+
+## Why the revenue looks so low
+
+This is the single most important thing on this page.
+
+**A channel is credited only with revenue invoiced *after* the touch that claims it, and within 90
+days of that touch.**
+
+Before this rule existed, the system credited a channel with everything the customer had *ever*
+spent. A customer who registered in 2022 and clicked a newsletter link yesterday handed that
+newsletter **€22,410** of trade the newsletter had nothing to do with. Applied across production,
+that inflation was the difference between a headline **€652,672** and the real **€1,439**.
+
+The smaller number is the true one. It says: *this is what the channel earned*, not *this is what its
+customers happen to have spent over their lifetime*.
+
+Two consequences to plan around:
+
+1. **The numbers start near zero and build.** Only trade after a recorded touch counts, and touches
+   have only been recorded since 7 August 2026. Expect weeks of thin figures. This is the system
+   filling up, not the system failing.
+2. **Wholesale reorder cycles are slow.** 90 days is chosen to suit them (Google Ads itself defaults
+   to 30). A customer who clicks in March and reorders in August is genuinely outside the window, and
+   that August order is not the March click's doing.
+
+The window can be set per shop if a shop's buying rhythm is different — ask engineering; it is a
+settings change, not a code change.
+
+## Share-weighting: why you will see 2.5 registrations
+
+A customer usually meets you more than once. If two channels touched them, **each channel gets half
+a customer, half their orders, half their revenue.** Three channels, a third each.
+
+That is why the screens show fractions — production currently shows registrations like `2.50`,
+`0.50`, `14.66`. A registration of 0.50 is one real customer whom this channel shares with another.
+
+The rule this guarantees: **every customer's shares add to exactly 1.00.** No channel can claim a
+customer another channel already claimed. Add up every channel of a shop and you get the shop's real
+total — never a number larger than reality. Alternative to a "the last click gets everything" model,
+which is easier to read but systematically over-credits whichever channel happens to close.
+
+---
+
+## What this system cannot tell you
+
+Be sceptical of any conclusion that depends on one of these.
+
+- **No cross-device tracking before login.** Touches are stored in the browser. Someone who sees the
+  ad on their phone and buys on their laptop looks like two different visitors — until they log in,
+  at which point the two histories are merged. Anonymous mobile→desktop journeys are simply lost.
+- **No view-through attribution.** An ad someone saw but did not click counts for nothing. Display
+  and social awareness campaigns will always look worse here than in the ad platform's own reporting,
+  which does count impressions. This is not a like-for-like comparison and never will be.
+- **Organic is only what we can recognise.** A visitor is credited to organic search or social only
+  if their browser tells us they arrived from a known site — Google, Bing, Facebook, Instagram,
+  Threads, Messenger, WhatsApp, YouTube, LinkedIn, Pinterest, TikTok, Twitter/X. Everything else —
+  typed the address, a bookmark, a link in a WhatsApp message on a phone, a private browsing session,
+  a referrer the browser withheld — records no touch at all and is invisible.
+- **Cleared cookies erase history.** A visitor who clears their browser data starts again from
+  nothing.
+- **Nothing before 7 August 2026.** There is no historic data to recover, and no way to backfill it.
+- **Email counts clicks, not opens.** Only a click on a newsletter or marketing mailshot is a touch.
+  Clicks in order confirmations, dispatch notices and invoices are deliberately ignored — those are
+  service emails to a customer who already bought.
+
+## Sanity-checking a figure that looks wrong
+
+Open the customer's page and go to the **marketing journey**. It shows every recorded touch and every
+invoice on one timeline, plus the resulting split.
+
+Work through it in this order:
+
+1. **Is there a touch at all before the invoice?** If the first touch is after the sale, that sale is
+   correctly not credited to it.
+2. **How many days between the touch and the invoice?** More than the window (90 by default) and the
+   revenue is correctly excluded.
+3. **How many channels touched this customer?** That is your denominator. Two channels and this
+   customer contributes 0.5 to each — the halved figure is right.
+4. **Is the channel you expected missing entirely?** Then no touch was recorded. Check the list of
+   blind spots above before assuming a bug; most "missing" traffic is untrackable traffic.
+
+If the timeline itself contradicts the totals, that is a real fault — see
+[troubleshooting.md](troubleshooting.md).
+
+## Rules of thumb
+
+- Compare channels within the same period, never one channel's all-time against another's 30 days.
+- Do not compare this system's revenue to the ad platform's own. They measure different things, count
+  impressions differently, and use different windows.
+- Treat a channel with very few registrations as noise. Under about twenty, one large order moves the
+  ROAS by a multiple.
+- Revenue is measured from **invoices**, not orders. An order placed but not yet invoiced counts for
+  nothing yet.

--- a/docs/marketing-attribution/troubleshooting.md
+++ b/docs/marketing-attribution/troubleshooting.md
@@ -1,0 +1,242 @@
+# Troubleshooting runbook
+
+Symptom → cause → fix. Every query below is read-only unless marked otherwise.
+
+---
+
+## ROAS or CAC shows a dash
+
+**Cause.** No advertising spend for that shop, channel and period. ROAS and CAC are only computed
+when spend is greater than zero — `null` renders as a dash. This is the state of every shop as of
+7 August 2026: `traffic_source_costs` is empty.
+
+```sql
+SELECT shop, channel, cost, revenue, roas FROM marketing_channel_performance WHERE cost > 0;
+```
+
+**Fix.** Import spend. Either the automated route (Google Ads script + a shop token) or a one-off CSV:
+
+```bash
+php artisan traffic-source:cost-token uk "AW Advantage"
+```
+
+```bash
+php artisan traffic-source:import-costs storage/app/spend.csv --dry-run
+```
+
+Then rebuild the campaign rollup:
+
+```bash
+php artisan traffic-source:hydrate-campaign-stats --shop=uk
+```
+
+If spend *is* present but ROAS is still a dash, check the period: the dashboard compares a period's
+revenue against **that period's** spend. Spend dated outside the selected range does not count.
+
+---
+
+## A shop captures nothing at all
+
+**Cause.** Almost always missing traffic source rows. A shop with no `traffic_sources` rows has
+nothing to attach touches to, so capture writes the cookie and the attachment then silently drops it.
+New shops and newly added `TrafficSourcesTypeEnum` cases both cause this.
+
+```sql
+SELECT s.slug, count(ts.id) AS sources
+FROM shops s LEFT JOIN traffic_sources ts ON ts.shop_id = s.id
+GROUP BY 1 HAVING count(ts.id) < 16 ORDER BY 2;
+```
+
+Sixteen is the current number of enum cases.
+
+**Fix.**
+
+```bash
+php artisan traffic-source:seed
+```
+
+Idempotent, runs across every shop, and also removes rows whose type has left the enum.
+
+**If the counts are fine**, the problem is upstream in capture — see the next two entries.
+
+---
+
+## Paid clicks land as organic, or not at all
+
+**Cause.** The landing URL is missing the click id. Capture checks paid parameters first and falls
+back to the referring domain, so a stripped `gclid` becomes organic Google.
+
+**Check.** Look at a real landing URL from the ad. It must carry `gclid` (Google), `msclkid` (Bing),
+or `fbclid` **plus** `utm_medium=paid` (Meta). Meta is the common failure — any other `utm_medium`
+and the click is not recognised as paid.
+
+**Fix.** Turn on auto-tagging in the ad platform; stop any redirect or landing-page rule that strips
+query parameters. See [utm-campaign-naming.md](utm-campaign-naming.md).
+
+---
+
+## Mailshot clicks are not attributed
+
+**Causes, in the order worth checking:**
+
+1. **The mailshot type is excluded.** Only `newsletter`, `marketing` and `invite` mailshots appear in
+   `marketing_mailshot_performance`, and only mailshot clicks create touches at all — transactional
+   email is deliberately excluded by the guard in `StoreEmailTrackingEvent`.
+2. **`DispatchedEmail::mailshot()` was used instead of `sentMailshot()`.** The former is dead; its
+   column was dropped in May 2025 and it returns null, which silently discards every click. This has
+   already happened once and cost a day.
+3. **The `ses-analytics` queue is stalled**, so `RecordEmailClickTouchpoint` never ran.
+
+```sql
+SELECT m.id, m.subject, ms.number_dispatched_emails_state_clicked AS clicks,
+       (SELECT count(*) FROM traffic_source_campaigns c WHERE c.reference = 'mailshot-'||m.id) AS campaign_row
+FROM mailshots m JOIN mailshot_stats ms ON ms.mailshot_id = m.id
+WHERE ms.number_dispatched_emails_state_clicked > 0
+ORDER BY m.id DESC LIMIT 20;
+```
+
+Clicks recorded but `campaign_row` at 0 points at cause 2 or 3.
+
+**Fix.** For a stalled queue, check Horizon and run `php artisan horizon:terminate` — workers keep
+running old code after a deploy. Attributed *revenue* of zero on a mailshot with clicks is usually
+correct and not a fault: see the next entry.
+
+---
+
+## Numbers dropped sharply after a deploy
+
+**Cause.** Almost certainly the attribution window landing. On 7 August 2026 it took production
+revenue from **€652,672 to €1,439**. That was the correction, not a regression: before it, a channel
+was credited with everything its customers had *ever* spent, including years of trade predating the
+touch. One newsletter click had claimed €22,410 of 2022 trade.
+
+**Confirm it is the window and not a fault.**
+
+```sql
+SELECT count(*) AS pivots,
+       count(*) FILTER (WHERE first_touch_at IS NULL) AS legacy_no_dates
+FROM model_has_traffic_sources WHERE model_type='Customer';
+```
+
+Then pick a customer whose revenue vanished and open their marketing journey. If every invoice
+predates the first touch, or falls more than 90 days after the last one, the drop is correct.
+
+**Fix.** None needed. If a shop genuinely has a longer buying cycle, widen its window rather than
+disabling the rule:
+
+```sql
+-- read the current value
+SELECT slug, settings->'marketing'->>'attribution_window_days' FROM shops WHERE slug='uk';
+```
+
+Set `settings.marketing.attribution_window_days` on the shop. `0` disables the window entirely and
+restores the old inflated behaviour — only ever useful as a comparison.
+
+> If you change the default in `config/marketing.php`, you **must** recreate the SQL views. The views
+> cannot read Laravel config and carry their own copy of the 90.
+
+---
+
+## Shares do not sum to 1.00
+
+**Cause.** A partially applied recalculation, or pivot rows written by two paths at once.
+
+```sql
+WITH per_customer AS (
+  SELECT model_id, round(sum(share),2) AS t
+  FROM model_has_traffic_sources WHERE model_type='Customer' GROUP BY model_id
+) SELECT t, count(*) FROM per_customer GROUP BY t ORDER BY 1;
+```
+
+Healthy output is a single row, `1.00`. On 7 August 2026: `1.00 | 331`.
+
+To see who is broken:
+
+```sql
+SELECT model_id, sum(share) FROM model_has_traffic_sources
+WHERE model_type='Customer' GROUP BY 1 HAVING round(sum(share),2) <> 1.00;
+```
+
+**Fix.** Rebuild from raw touch history — always dry-run first:
+
+```bash
+php artisan traffic-source:recalculate-attribution --shop=uk --dry-run
+```
+
+```bash
+php artisan traffic-source:recalculate-attribution --shop=uk
+```
+
+```bash
+php artisan traffic-source:hydrate-campaign-stats --shop=uk
+```
+
+Then re-run the invariant query. Note that **order** pivots are not recalculable — an order carries
+no touch history, only a snapshot taken at submission. Only customer rows are covered by the check
+and by the command.
+
+---
+
+## A migration fails on deploy, complaining about a view
+
+**Cause.** The four `marketing_*` views hold Postgres dependencies on the columns they select. Any
+migration altering `traffic_source_stats`, `mailshot_stats`, `customer_stats`, `invoices` or
+`traffic_source_costs` is blocked by them.
+
+**Fix.** Drop the views at the top of the migration and recreate them at the end. Copy the
+definitions from `2026_08_07_150000_apply_attribution_window_to_marketing_views.php`, which holds the
+current version of all four.
+
+---
+
+## Rollback
+
+### Turning attribution off in a hurry
+
+There is no kill switch, and none is needed — the pieces are independently disableable, and none of
+them blocks trading.
+
+| To stop | Do this | Effect |
+| --- | --- | --- |
+| Revenue attribution distorting reports | Set `settings.marketing.attribution_window_days` to `0` on the shop | Reverts to the pre-window behaviour: causality still applies, but a touch claims the customer's whole history. Reversible instantly. |
+| Automated spend arriving | `php artisan traffic-source:cost-token --revoke=<id>` | The ad-platform script gets a 401. No data lost; already-imported rows stay. |
+| Stats jobs consuming workers | Pause the `low-priority` and `ses-analytics` queues in Horizon | Touches keep being *recorded*; only the rollups go stale. Resume and re-hydrate to catch up. |
+| Everything, at the source | Comment out the `CaptureTrafficSource::run()` call in `app/Actions/Traits/HasIrisUserData.php` and deploy | No new touch cookies are written. Existing data untouched. |
+
+Do **not** truncate `model_has_traffic_sources` as a rollback move. It is cheaper to zero the window.
+
+### What would actually be lost
+
+| Data | Recoverable? |
+| --- | --- |
+| `customers.traffic_sources` — raw touch history | **No. This is the source of truth.** Nothing rebuilds it. Never clear this column. |
+| `model_has_traffic_sources` for Customers | Yes — `traffic-source:recalculate-attribution`. |
+| `model_has_traffic_sources` for Orders | **No.** An order's attribution is a snapshot taken at submission from a customer history that may since have changed. There is nothing to rebuild it from. |
+| `traffic_source_stats`, `traffic_source_campaign_stats` | Yes — the hydrators, then `traffic-source:hydrate-campaign-stats`. |
+| `traffic_source_campaigns` | Partly. Numeric refs are recreated from touches on recalculation; the human names imported with spend are not. |
+| `traffic_source_costs` | Only from the ad platform. Re-run the ingestion script for the affected dates or re-import the CSV; the upsert is keyed on source + campaign + date, so re-running is safe. |
+| The four `marketing_*` views | Yes — re-run the view migration. |
+
+### Restoring after a rollback
+
+```bash
+php artisan traffic-source:seed
+```
+
+```bash
+php artisan traffic-source:recalculate-attribution --dry-run
+```
+
+```bash
+php artisan traffic-source:recalculate-attribution
+```
+
+```bash
+php artisan traffic-source:hydrate-campaign-stats
+```
+
+```bash
+php artisan horizon:terminate
+```
+
+Then check the shares-sum-to-1.00 invariant above before telling anyone the numbers are back.

--- a/docs/marketing-attribution/utm-campaign-naming.md
+++ b/docs/marketing-attribution/utm-campaign-naming.md
@@ -1,0 +1,143 @@
+# UTM and campaign naming standard
+
+Proposed. For whoever builds ad links — in-house or agency.
+
+## What capture actually requires today
+
+Checked against `GetTrafficSourceFromUrl` on 7 August 2026. These are the only things that make a
+paid click register:
+
+| Channel | Landing URL must contain | Campaign reference taken from |
+| --- | --- | --- |
+| Google Ads | `gclid` | `gad_campaignid`, if present |
+| Meta Ads | `fbclid` **and** `utm_medium=paid` | `utm_campaign` |
+| Bing Ads | `msclkid` | none — Bing records no campaign |
+
+`gclid`, `fbclid` and `msclkid` are appended by the platforms themselves when auto-tagging is on. You
+do not add them; you must not strip them.
+
+Two notes that correct older internal guidance:
+
+- **`gclid` alone is now sufficient for Google.** An earlier version required `gad_source` *and*
+  `gad_campaignid` *and* `gclid`, and clicks arriving with only `gclid` — custom tracking templates,
+  certain placement types — fell through to the organic referer fallback. That gap is closed. Adding
+  `gad_campaignid` still buys you the campaign breakdown.
+- **Bing campaign-level reporting does not exist and is not a bug.** `msclkid` is unique per click, so
+  using it as a campaign reference made every single click its own campaign, over-weighted Bing in
+  the share split, and matched no imported cost row ever. Bing reports at channel level only.
+
+## The hard constraint
+
+> A campaign row is created automatically **only** for a reference of 1–20 digits
+> (`^\d{1,20}$`, `AttachTrafficSourcesToModel`).
+
+Touch strings come from a cookie the visitor controls. Without that restriction anyone could mint
+unlimited campaign rows named whatever they liked.
+
+So a readable string in `utm_campaign` — `summer-sale-2026` — **is silently discarded as a campaign
+reference.** The click still counts for the channel; it just gets no campaign breakdown. This is why
+production currently has exactly one paid campaign row, `21723300927`, alongside 38 `mailshot-N` rows
+created server-side.
+
+**Therefore: campaign references stay numeric platform ids. Human readability lives in the campaign
+name inside the ad platform, not in the URL.** Anything else needs a code change.
+
+## The standard
+
+### 1. Name campaigns in the ad platform, to a fixed shape
+
+The platform's own campaign name is what a person reads. Lower case, hyphens, five fields:
+
+```
+<shop>-<objective>-<audience>-<offer>-<yyyymm>
+```
+
+| Field | Values |
+| --- | --- |
+| `shop` | Shop slug exactly as in Aiku: `uk`, `es`, `freu`, `iteu`, `plsk`, `ade`, `eu`, … |
+| `objective` | `acq` (acquisition), `ret` (retention), `brand` |
+| `audience` | `trade`, `retail`, `lapsed`, `lookalike`, `remarketing` |
+| `offer` | Short slug, no spaces: `teak25`, `backtoschool`, `evergreen` |
+| `yyyymm` | Month the campaign starts. |
+
+```
+uk-acq-trade-teak25-202608
+es-ret-lapsed-evergreen-202609
+```
+
+Keep it stable for the life of the campaign. Renaming mid-flight breaks the join between imported
+spend and attributed revenue.
+
+### 2. Let the platform supply the click id — auto-tagging on
+
+- **Google Ads:** auto-tagging **on** (Account settings → Auto-tagging). This is what produces
+  `gclid`; without it the click is invisible to attribution. Leave the final URL suffix alone unless
+  you are adding `gad_campaignid`.
+- **Microsoft/Bing Ads:** auto-tagging **on**, producing `msclkid`.
+- **Meta:** auto-tagging produces `fbclid`, but Meta clicks additionally require `utm_medium=paid` —
+  see below.
+
+### 3. UTM parameters
+
+| Parameter | Google | Meta | Bing |
+| --- | --- | --- | --- |
+| `utm_source` | `google` | `meta` | `bing` |
+| `utm_medium` | `cpc` | **`paid`** (required) | `cpc` |
+| `utm_campaign` | platform campaign id | **Meta campaign id, numeric** | platform campaign id |
+| `utm_content` | free — ad or creative name | free | free |
+
+Two things are load-bearing and everything else is convenience:
+
+- **Meta must send `utm_medium=paid`.** Any other value and the click is not recognised as Meta Ads.
+  It falls through to the organic-referrer check and is credited to organic Meta or dropped entirely.
+- **`utm_campaign` must be the numeric campaign id, not the name.** On Meta use the dynamic macro
+  `{{campaign.id}}`; the readable name is the one you set in step 1.
+
+Meta URL template:
+
+```
+https://<shop-domain>/<landing-path>?utm_source=meta&utm_medium=paid&utm_campaign={{campaign.id}}&utm_content={{ad.name}}
+```
+
+Google — auto-tagging supplies `gclid`; add the campaign id explicitly to get the breakdown:
+
+```
+?utm_source=google&utm_medium=cpc&utm_campaign={campaignid}&gad_campaignid={campaignid}
+```
+
+Bing needs nothing beyond auto-tagging. UTMs on Bing links are harmless documentation.
+
+### 4. Never put these in a campaign reference
+
+`|`, `,` or whitespace. The touch string uses `|` as its separator, so either character inside a
+reference shatters the visitor's whole history into garbage on parse. Capture sanitises them to `-`,
+but the reference then no longer matches your cost import.
+
+### 5. Email
+
+Mailshot references are generated server-side as `mailshot-<id>` and named from the mailshot subject.
+Nothing to configure, and nothing to name by hand.
+
+## Making it show up as a readable name
+
+Auto-created campaign rows are named after their numeric reference. Give them the platform name from
+step 1 in one of two ways:
+
+- **The Google Ads ingestion script does it for you.** It sends `campaign.name` alongside
+  `campaign.id`, and the webhook creates or names the campaign row from it (see
+  [../google-ads-cost-ingestion/README.md](../google-ads-cost-ingestion/README.md)). Name your Google
+  campaigns to the step-1 shape and the dashboard reads properly with no further work.
+- **The CSV import does not.** `traffic-source:import-costs` has no name column and *fails the row*
+  if the campaign reference does not already exist for that source and shop. Use it for spend on
+  campaigns that have already been seen in a click.
+- Otherwise edit the campaign row's `name` directly. The `reference` must never be edited.
+
+## Known gaps
+
+- **Campaign-level attribution is Google and Meta only.** Bing is channel-level by design.
+- **Non-numeric campaign references are dropped.** If you ever need readable references, campaign
+  auto-creation needs a server-side allow-list — a code change, not a naming decision.
+- **No view-through.** Impression-only exposure is not captured on any channel.
+- **`utm_source` and `utm_content` are recorded nowhere.** They are for the ad platform's own
+  reporting and cost imports; Aiku attribution ignores them. Only the three parameters in bold above
+  change what Aiku records.


### PR DESCRIPTION
Phase 8 of marketing attribution: documentation only. No code changes.

Four documents under \`docs/marketing-attribution/\`, alongside the existing \`docs/google-ads-cost-ingestion/\`:

- **reading-the-numbers.md** — marketing and management. ROAS/CAC, why revenue looks low (the causality + 90-day window rule, and the €652,672 → €1,439 correction), share-weighting and why registrations are fractional, the system's blind spots, and how to sanity-check a figure from the customer journey timeline.
- **engineering.md** — touch string format, the polymorphic pivot, the two places the attribution window is enforced (\`WithAttributionWindow\` and \`marketing_attributable_invoices\`) and that they must stay in step, the five artisan commands, the job queues, and the standing trap that the four \`marketing_*\` views block schema changes.
- **utm-campaign-naming.md** — proposed naming standard, compatible with what capture actually requires today.
- **troubleshooting.md** — symptom → cause → fix, plus the rollback note (what is lost vs. rebuildable).

Every command, file path and behaviour was checked against the code or read-only production, not written from memory. Two corrections to earlier internal guidance came out of that:

- The gclid-only gap is **already closed** — \`GetTrafficSourceFromUrl\` now accepts \`gclid\` alone for Google; it no longer demands \`gad_source\` + \`gad_campaignid\` too.
- Campaign auto-creation is restricted to **numeric** references, so a readable \`utm_campaign\` string is silently discarded. The naming standard is built around that constraint rather than against it.

Production facts cited (checked 7 Aug 2026): 331 customers of 610,019 carry touch data; 39 campaigns (1 Google Ads id, 38 mailshots); 0 cost rows, so ROAS is a dash everywhere; shares sum to 1.00 for all 331 customers.