### PR TITLE
📐 Traffic sources listing: right-align counts, drop money-like decimals

### DIFF
--- a/app/Actions/CRM/TrafficSource/UI/IndexTrafficSources.php
+++ b/app/Actions/CRM/TrafficSource/UI/IndexTrafficSources.php
@@ -69,8 +69,11 @@ class IndexTrafficSources extends OrgAction
             'traffic_sources.id',
             'traffic_sources.slug',
             'traffic_sources.name',
-            'traffic_source_stats.number_customers',
-            'traffic_source_stats.number_customer_purchases',
+            /* Both counts are share weighted, so they are stored fractional: a customer credited to two
+               channels is half a customer to each. Whole values still have to read as counts rather
+               than as money, so the trailing zeros come off and only a genuine fraction keeps them. */
+            DB::raw('trim_scale(traffic_source_stats.number_customers) as number_customers'),
+            DB::raw('trim_scale(traffic_source_stats.number_customer_purchases) as number_customer_purchases'),
             "traffic_source_stats.{$revenueField} as total_customer_revenue",
             "traffic_source_stats.{$costField} as cost",
             'currencies.code as currency_code',
@@ -130,11 +133,11 @@ class IndexTrafficSources extends OrgAction
 
             $table
                 ->column(key: 'name', label: __('Name'), canBeHidden: false, sortable: true, searchable: true)
-                ->column(key: 'number_customers', label: __('Registrations'), canBeHidden: false, sortable: true, searchable: true)
-                ->column(key: 'number_customer_purchases', label: __('Orders'), canBeHidden: false, sortable: true)
+                ->column(key: 'number_customers', label: __('Registrations'), canBeHidden: false, sortable: true, searchable: true, align: 'right')
+                ->column(key: 'number_customer_purchases', label: __('Orders'), canBeHidden: false, sortable: true, align: 'right')
                 ->column(key: 'cost', label: __('Cost'), canBeHidden: false, sortable: true, type: 'currency')
                 ->column(key: 'total_customer_revenue', label: __('Revenue'), canBeHidden: false, sortable: true, type: 'currency')
-                ->column(key: 'roas', label: __('ROAS'), canBeHidden: true, sortable: true)
+                ->column(key: 'roas', label: __('ROAS'), canBeHidden: true, sortable: true, align: 'right')
                 ->column(key: 'cac', label: __('CAC'), canBeHidden: true, sortable: true, type: 'currency');
         };
     }

--- a/tests/Feature/CRM/TrafficSourceCostTest.php
+++ b/tests/Feature/CRM/TrafficSourceCostTest.php
@@ -214,3 +214,18 @@ it('reports no roas or cac for a source with no recorded spend', function () {
     expect($row->roas)->toBeNull();
     expect($row->cac)->toBeNull();
 });
+
+it('renders whole share weighted counts without decimals and keeps genuine fractions', function () {
+    $this->trafficSource->stats()->update([
+        'number_customers'          => 333.00,
+        'number_customer_purchases' => 0.50,
+    ]);
+
+    fakeCurrentRoute();
+
+    $row = IndexTrafficSources::make()->handle($this->shop)
+        ->firstWhere('id', $this->trafficSource->id);
+
+    expect($row->number_customers)->toBe('333')
+        ->and($row->number_customer_purchases)->toBe('0.5');
+});


### PR DESCRIPTION
Reported from the `aw/uk` traffic sources listing: **Orders 333.00** reads as an amount of money, and the number columns sit left-aligned against the text ones.

## What it is

`number_customers` and `number_customer_purchases` are share-weighted — a customer credited to two channels is half a customer to each — so [a migration on 6 Aug](database/migrations/2026_08_06_210000_make_traffic_source_stats_counts_fractional.php) made them `decimal(12,2)`. Postgres then renders every whole value with two trailing zeros, and the table left-aligns them because the values arrive as strings rather than numbers.

## Fix

- `trim_scale()` on both counts in the select: `333.00` → `333`, while a genuine `0.50` → `0.5` and stays visible. Nothing is rounded away.
- `align: 'right'` on Registrations, Orders and ROAS. Cost, Revenue and CAC are already right-aligned via `type: 'currency'`.

Postgres 18 in prod; `trim_scale()` is 13+.

## Test

One case added to `TrafficSourceCostTest`: a whole count renders `333`, a fractional one renders `0.5`. File passes (10 tests).

---

Presentation only. Separate from the causality problem on the same screen — that **Registrations** column counts customers whose touch happened *after* they registered (on `uk` today: 120 of 120 touches), which needs its own change and its own review.