### PR TITLE
🎯 A touch can only claim registrations and orders that came after it

### DIFF
--- a/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
+++ b/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
@@ -45,7 +45,7 @@ class GetShopMarketingOverview
 
         $window        = GetAttributionWindow::run($shop);
         $revenue       = $this->revenueBySource($shop, $from, $window);
-        $registrations = $this->registrationsBySource($shop, $from);
+        $registrations = $this->registrationsBySource($shop, $from, $window);
         $spend         = $this->spendBySource($shop, $from);
 
         $channels = $sources
@@ -116,12 +116,19 @@ class GetShopMarketingOverview
             ->keyBy('traffic_source_id');
     }
 
-    private function registrationsBySource(Shop $shop, ?Carbon $from)
+    /**
+     * Registrations a channel may claim: the same causality the revenue figure obeys. A touch cannot
+     * have acquired a customer who was already registered when it happened, which is why newsletter
+     * once appeared to acquire a hundred customers it had only mailed.
+     */
+    private function registrationsBySource(Shop $shop, ?Carbon $from, int $window)
     {
         return DB::table('customers')
-            ->join('model_has_traffic_sources as p', function ($join) {
+            ->join('model_has_traffic_sources as p', function ($join) use ($window) {
                 $join->on('p.model_id', '=', 'customers.id')
                     ->where('p.model_type', '=', 'Customer');
+
+                $this->constrainToTouchWindow($join, 'customers.created_at', $window);
             })
             ->where('customers.shop_id', $shop->id)
             ->when($from, fn ($query) => $query->where('customers.created_at', '>=', $from))

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceCampaignHydrateStats.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceCampaignHydrateStats.php
@@ -10,6 +10,7 @@ namespace App\Actions\CRM\TrafficSource\Hydrator;
 
 use App\Actions\CRM\TrafficSource\GetAttributionWindow;
 use App\Actions\CRM\TrafficSource\WithAttributionWindow;
+use App\Enums\Ordering\Order\OrderStateEnum;
 use App\Models\CRM\TrafficSourceCampaign;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\DB;
@@ -41,17 +42,24 @@ class TrafficSourceCampaignHydrateStats implements ShouldBeUnique
      */
     public function handle(TrafficSourceCampaign $campaign): void
     {
-        $attribution = DB::table('model_has_traffic_sources')
-            ->join('customer_stats', 'customer_stats.customer_id', '=', 'model_has_traffic_sources.model_id')
-            ->where('model_has_traffic_sources.traffic_source_campaign_id', $campaign->id)
-            ->where('model_has_traffic_sources.model_type', 'Customer')
-            ->select(
-                DB::raw('COALESCE(SUM(model_has_traffic_sources.share), 0) as customers'),
-                DB::raw('COALESCE(SUM(customer_stats.number_orders_state_dispatched * model_has_traffic_sources.share), 0) as purchases'),
-            )
-            ->first();
+        $window = GetAttributionWindow::run($campaign->trafficSource->shop);
 
-        $window  = GetAttributionWindow::run($campaign->trafficSource->shop);
+        $customers = DB::table('model_has_traffic_sources as p')
+            ->join('customers', 'customers.id', '=', 'p.model_id')
+            ->where('p.traffic_source_campaign_id', $campaign->id)
+            ->where('p.model_type', 'Customer')
+            ->tap(fn ($query) => $this->constrainToTouchWindow($query, 'customers.created_at', $window))
+            ->sum('p.share');
+
+        $purchases = DB::table('model_has_traffic_sources as p')
+            ->join('orders', 'orders.customer_id', '=', 'p.model_id')
+            ->where('p.traffic_source_campaign_id', $campaign->id)
+            ->where('p.model_type', 'Customer')
+            ->where('orders.state', OrderStateEnum::DISPATCHED)
+            ->whereNull('orders.deleted_at')
+            ->tap(fn ($query) => $this->constrainToTouchWindow($query, 'orders.date', $window))
+            ->sum('p.share');
+
         $revenue = DB::table('invoices')
             ->join('model_has_traffic_sources as p', function ($join) use ($window) {
                 $join->on('p.model_id', '=', 'invoices.customer_id')
@@ -78,8 +86,8 @@ class TrafficSourceCampaignHydrateStats implements ShouldBeUnique
         $campaign->stats()->updateOrCreate(
             ['traffic_source_campaign_id' => $campaign->id],
             [
-                'number_customers'           => $attribution->customers,
-                'number_customer_purchases'  => $attribution->purchases,
+                'number_customers'           => $customers,
+                'number_customer_purchases'  => $purchases,
                 'total_customer_revenue'     => $revenue->revenue,
                 'org_total_customer_revenue' => $revenue->org_revenue,
                 'total_cost'                 => $cost->total,

--- a/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
+++ b/app/Actions/CRM/TrafficSource/Hydrator/TrafficSourceHydrateCustomers.php
@@ -14,11 +14,14 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 use App\Actions\CRM\TrafficSource\GetAttributionWindow;
+use App\Actions\CRM\TrafficSource\WithAttributionWindow;
+use App\Enums\Ordering\Order\OrderStateEnum;
 use App\Models\CRM\TrafficSource;
 
 class TrafficSourceHydrateCustomers implements ShouldBeUnique
 {
     use AsAction;
+    use WithAttributionWindow;
 
     /* Fired from every registration, order cancel and email-click recalculation; the numbers it
        refreshes are dashboard statistics, so it must never compete with order processing. */
@@ -35,43 +38,41 @@ class TrafficSourceHydrateCustomers implements ShouldBeUnique
      * figures across every traffic source of a shop therefore reproduces the shop's real totals —
      * channels share the credit, they never each claim the whole of it.
      *
-     * Revenue is what the channel actually earned, not what its customers have ever spent: only
-     * invoices raised after a touch, and within the shop's attribution window, are counted. Before
-     * this, a customer registered in 2022 who clicked a newsletter yesterday handed that newsletter
-     * four years of prior trade, and the listing reported it as marketing performance.
+     * Every figure here answers "what did this channel bring in", not "what have its customers ever
+     * done": a registration, an order or an invoice counts only if it happened after the touch and
+     * inside the shop's attribution window. Before this, a customer registered in 2022 who clicked a
+     * newsletter yesterday handed that newsletter four years of prior trade and their registration
+     * too, and the listing reported it as marketing performance.
      */
     public function handle(TrafficSource $trafficSource): void
     {
-        $counts = DB::table('model_has_traffic_sources')
-            ->join('customer_stats', 'customer_stats.customer_id', '=', 'model_has_traffic_sources.model_id')
-            ->where('model_has_traffic_sources.traffic_source_id', $trafficSource->id)
-            ->where('model_has_traffic_sources.model_type', 'Customer')
-            ->select(
-                DB::raw('COALESCE(SUM(model_has_traffic_sources.share), 0) as customers'),
-                DB::raw('COALESCE(SUM(customer_stats.number_orders_state_dispatched * model_has_traffic_sources.share), 0) as purchases'),
-            )
-            ->first();
-
         $window = GetAttributionWindow::run($trafficSource->shop);
+
+        $customers = DB::table('model_has_traffic_sources as p')
+            ->join('customers', 'customers.id', '=', 'p.model_id')
+            ->where('p.traffic_source_id', $trafficSource->id)
+            ->where('p.model_type', 'Customer')
+            ->tap(fn ($query) => $this->constrainToTouchWindow($query, 'customers.created_at', $window))
+            ->sum('p.share');
+
+        /* Counted from the orders themselves rather than from customer_stats: the rollup carries no
+           dates, so there is no way to tell an order the channel earned from one placed years before
+           the touch existed. */
+        $purchases = DB::table('model_has_traffic_sources as p')
+            ->join('orders', 'orders.customer_id', '=', 'p.model_id')
+            ->where('p.traffic_source_id', $trafficSource->id)
+            ->where('p.model_type', 'Customer')
+            ->where('orders.state', OrderStateEnum::DISPATCHED)
+            ->whereNull('orders.deleted_at')
+            ->tap(fn ($query) => $this->constrainToTouchWindow($query, 'orders.date', $window))
+            ->sum('p.share');
 
         $revenue = DB::table('invoices')
             ->join('model_has_traffic_sources as p', function ($join) use ($window) {
                 $join->on('p.model_id', '=', 'invoices.customer_id')
                     ->where('p.model_type', '=', 'Customer');
 
-                $join->where(function ($q) use ($window) {
-                    $q->whereNull('p.first_touch_at')
-                        ->orWhere(function ($inWindow) use ($window) {
-                            $inWindow->whereColumn('invoices.date', '>=', 'p.first_touch_at');
-
-                            if ($window > 0) {
-                                $inWindow->whereRaw(
-                                    "invoices.date <= p.last_touch_at + (? || ' days')::interval",
-                                    [$window]
-                                );
-                            }
-                        });
-                });
+                $this->constrainToAttributionWindow($join, $window);
             })
             ->where('p.traffic_source_id', $trafficSource->id)
             ->where('invoices.in_process', false)
@@ -82,8 +83,8 @@ class TrafficSourceHydrateCustomers implements ShouldBeUnique
             ->first();
 
         $totals = (object) [
-            'customers'   => $counts->customers,
-            'purchases'   => $counts->purchases,
+            'customers'   => $customers,
+            'purchases'   => $purchases,
             'revenue'     => $revenue->revenue,
             'org_revenue' => $revenue->org_revenue,
         ];

--- a/app/Actions/CRM/TrafficSource/WithAttributionWindow.php
+++ b/app/Actions/CRM/TrafficSource/WithAttributionWindow.php
@@ -18,6 +18,8 @@ namespace App\Actions\CRM\TrafficSource;
  */
 trait WithAttributionWindow
 {
+    use WithTouchCausality;
+
     /**
      * Revenue counts when it was invoiced after the touch that earned it, and no later than the
      * window allows. Rows with no recorded touch date are legacy and are left in rather than
@@ -27,18 +29,6 @@ trait WithAttributionWindow
      */
     protected function constrainToAttributionWindow($join, int $window, string $pivotAlias = 'p'): void
     {
-        $join->where(function ($query) use ($window, $pivotAlias) {
-            $query->whereNull($pivotAlias.'.first_touch_at')
-                ->orWhere(function ($inWindow) use ($window, $pivotAlias) {
-                    $inWindow->whereColumn('invoices.date', '>=', $pivotAlias.'.first_touch_at');
-
-                    if ($window > 0) {
-                        $inWindow->whereRaw(
-                            "invoices.date <= {$pivotAlias}.last_touch_at + (? || ' days')::interval",
-                            [$window]
-                        );
-                    }
-                });
-        });
+        $this->constrainToTouchWindow($join, 'invoices.date', $window, $pivotAlias);
     }
 }

--- a/app/Actions/CRM/TrafficSource/WithTouchCausality.php
+++ b/app/Actions/CRM/TrafficSource/WithTouchCausality.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\TrafficSource;
+
+/**
+ * The rule that decides whether a marketing touch may claim something that happened to the customer,
+ * stated once and applied to whichever date column asks: an invoice's date, a registration's, an
+ * order's. A touch claims only what came after it, and only within the shop's attribution window.
+ *
+ * [[WithAttributionWindow]] is the invoice-shaped face of this rule and delegates here, so revenue
+ * and counts can never drift apart again the way separate copies once let a channel's campaigns
+ * out-earn the channel itself.
+ */
+trait WithTouchCausality
+{
+    /**
+     * Rows with no recorded touch date are legacy and are left in rather than silently dropped, so
+     * historic attribution does not vanish the day this ships.
+     *
+     * @param \Illuminate\Database\Query\JoinClause|\Illuminate\Database\Query\Builder $query
+     */
+    protected function constrainToTouchWindow($query, string $dateColumn, int $window, string $pivotAlias = 'p'): void
+    {
+        $query->where(function ($query) use ($dateColumn, $window, $pivotAlias) {
+            $query->whereNull($pivotAlias.'.first_touch_at')
+                ->orWhere(function ($inWindow) use ($dateColumn, $window, $pivotAlias) {
+                    $inWindow->whereColumn($dateColumn, '>=', $pivotAlias.'.first_touch_at');
+
+                    if ($window > 0) {
+                        $inWindow->whereRaw(
+                            "{$dateColumn} <= {$pivotAlias}.last_touch_at + (? || ' days')::interval",
+                            [$window]
+                        );
+                    }
+                });
+        });
+    }
+}

--- a/app/Actions/Ordering/Order/UpdateState/CancelOrder.php
+++ b/app/Actions/Ordering/Order/UpdateState/CancelOrder.php
@@ -145,15 +145,15 @@ class CancelOrder extends OrgAction
     }
 
     /**
-     * TrafficSourceHydrateCustomers re-sums `customer_stats` across every customer a traffic source is
-     * credited with, and cancelling this order changes this customer's totals, so every source crediting
-     * either the order or the customer holds a stale revenue figure until it is rehydrated.
+     * TrafficSourceHydrateCustomers re-sums the orders and invoices of every customer a traffic source
+     * is credited with, and cancelling this order changes this customer's totals, so every source
+     * crediting either the order or the customer holds a stale figure until it is rehydrated.
      *
      * The pivot attribution rows themselves are preserved as an audit trail of what originally
      * acquired the order.
      *
-     * ponytail: the extra delay is what keeps this from reading `customer_stats` before the order
-     * hydrators above have written it. Chain it after CustomerHydrateOrderStats if queue depth ever
+     * ponytail: the extra delay keeps this from reading the customer's rollups before the order
+     * hydrators above have written them. Chain it after CustomerHydrateOrderStats if queue depth ever
      * makes a fixed offset unreliable.
      */
     private function refreshTrafficSourceStats(Order $order): void

--- a/app/Console/Commands/HydrateTrafficSourceStats.php
+++ b/app/Console/Commands/HydrateTrafficSourceStats.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Console\Commands;
+
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
+use App\Models\Catalogue\Shop;
+use App\Models\CRM\TrafficSource;
+use Illuminate\Console\Command;
+
+class HydrateTrafficSourceStats extends Command
+{
+    protected $signature = 'traffic-source:hydrate-stats {--shop= : Only traffic sources of a specific shop slug}';
+
+    protected $description = 'Rebuild the stats rollup of every traffic source from its attribution';
+
+    /**
+     * Source stats are otherwise only refreshed when a touch fires for that source, so a change to how
+     * they are counted leaves every quiet channel showing the old figure until this is run. Safe to
+     * rerun.
+     */
+    public function handle(): int
+    {
+        $query = TrafficSource::query();
+
+        if ($shopSlug = $this->option('shop')) {
+            $shop = Shop::where('slug', $shopSlug)->first();
+
+            if (!$shop) {
+                $this->error("Shop '{$shopSlug}' not found.");
+
+                return Command::FAILURE;
+            }
+
+            $query->where('shop_id', $shop->id);
+        }
+
+        $total = $query->count();
+
+        if ($total === 0) {
+            $this->info('No traffic sources to hydrate.');
+
+            return Command::SUCCESS;
+        }
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $query->chunkById(200, function ($trafficSources) use ($bar) {
+            foreach ($trafficSources as $trafficSource) {
+                TrafficSourceHydrateCustomers::run($trafficSource);
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Hydrated {$total} traffic source(s).");
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Feature/CRM/EmailMarketingPerformanceTest.php
+++ b/tests/Feature/CRM/EmailMarketingPerformanceTest.php
@@ -68,9 +68,9 @@ it('splits customer credit between channels so their stats sum to the real total
     RecordEmailClickTouchpoint::run($this->customer->fresh(), now()->subDays(10));
 
     createInvoiceFor($this->customer, $this->shop, now()->subDay()->toDateTimeString(), 1000);
-    DB::table('customer_stats')->where('customer_id', $this->customer->id)->update([
-        'number_orders_state_dispatched' => 4,
-    ]);
+    foreach (range(1, 4) as $ignored) {
+        createDispatchedOrderFor($this->customer, $this->shop, now()->subDay()->toDateTimeString());
+    }
 
     TrafficSourceHydrateCustomers::run($this->googleAds);
     TrafficSourceHydrateCustomers::run($this->newsletter);

--- a/tests/Feature/CRM/TrafficSourceAttributionTest.php
+++ b/tests/Feature/CRM/TrafficSourceAttributionTest.php
@@ -9,6 +9,7 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 
 use App\Actions\CRM\Customer\StoreCustomer;
+use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
 use App\Models\CRM\Customer;
 use App\Models\CRM\TrafficSourceCampaign;
 use Illuminate\Support\Facades\Artisan;
@@ -166,4 +167,38 @@ it('ignores blank traffic source data', function () {
     );
 
     expect($customer->trafficSources()->count())->toBe(0);
+});
+
+it('does not credit a channel with a registration that happened before the touch', function () {
+    $newsletter = createTrafficSource($this->shop, 'newsletter', 'Newsletter');
+    $customer   = createCustomer($this->shop);
+    $customer->trafficSources()->detach();
+    $customer->update(['created_at' => now()->subDays(30)]);
+
+    $customer->trafficSources()->attach($newsletter->id, [
+        'share'          => 1,
+        'first_touch_at' => now()->subDay(),
+        'last_touch_at'  => now()->subDay(),
+    ]);
+
+    TrafficSourceHydrateCustomers::run($newsletter);
+
+    expect((float) $newsletter->stats->fresh()->number_customers)->toBe(0.0);
+});
+
+it('credits a channel with a registration that followed the touch', function () {
+    $organic  = createTrafficSource($this->shop, 'organic-google', 'Organic Google');
+    $customer = createCustomer($this->shop);
+    $customer->trafficSources()->detach();
+    $customer->update(['created_at' => now()->subDay()]);
+
+    $customer->trafficSources()->attach($organic->id, [
+        'share'          => 1,
+        'first_touch_at' => now()->subDays(2),
+        'last_touch_at'  => now()->subDays(2),
+    ]);
+
+    TrafficSourceHydrateCustomers::run($organic);
+
+    expect((float) $organic->stats->fresh()->number_customers)->toBe(1.0);
 });

--- a/tests/Feature/CRM/TrafficSourceCampaignStatsTest.php
+++ b/tests/Feature/CRM/TrafficSourceCampaignStatsTest.php
@@ -18,7 +18,6 @@ use App\Models\CRM\Customer;
 use App\Models\CRM\TrafficSourceCampaign;
 use App\Models\CRM\TrafficSourceCost;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\DB;
 
 beforeAll(function () {
     loadDB();
@@ -57,9 +56,10 @@ it('rolls a campaign\'s attributed customers and revenue into its own stats', fu
     );
 
     createInvoiceFor($customer, $this->shop, now()->subDay()->toDateTimeString(), 900);
-    DB::table('customer_stats')->where('customer_id', $customer->id)->update([
-        'number_orders_state_dispatched' => 3,
-    ]);
+
+    foreach (range(1, 3) as $ignored) {
+        createDispatchedOrderFor($customer, $this->shop, now()->subDay()->toDateTimeString());
+    }
 
     $campaign = TrafficSourceCampaign::where('reference', $reference)->firstOrFail();
     TrafficSourceCampaignHydrateStats::run($campaign);

--- a/tests/Feature/CRM/TrafficSourceCostTest.php
+++ b/tests/Feature/CRM/TrafficSourceCostTest.php
@@ -178,7 +178,7 @@ it('aggregates period spend per channel into the marketing overview', function (
     // A channel with attributed customers but no spend still has to appear, with no ROAS to show.
     $customer = createCustomer($this->shop);
     $customer->trafficSources()->detach();
-    $customer->update(['traffic_sources' => '1700000000a']);
+    $customer->update(['traffic_sources' => now()->subDays(2)->timestamp.'a']);
     App\Actions\CRM\TrafficSource\RecalculateTrafficSourceAttribution::run($customer->fresh());
 
     $overview = GetShopMarketingOverview::run($this->shop, App\Enums\UI\Marketing\MarketingPeriodEnum::ALL_TIME);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -270,6 +270,30 @@ function createInvoiceFor($customer, $shop, string $date, float $net, bool $inPr
     ]);
 }
 
+/**
+ * A channel's order count is measured from the orders themselves, since only they carry the date that
+ * says whether the order came after the touch claiming it.
+ */
+function createDispatchedOrderFor($customer, $shop, string $date): void
+{
+    \Illuminate\Support\Facades\DB::table('orders')->insert([
+        'group_id'        => $shop->group_id,
+        'organisation_id' => $shop->organisation_id,
+        'shop_id'         => $shop->id,
+        'customer_id'     => $customer->id,
+        'currency_id'     => $shop->currency_id,
+        'tax_category_id' => \App\Models\Helpers\TaxCategory::firstOrFail()->id,
+        'slug'            => 'ord-'.uniqid(),
+        'state'           => \App\Enums\Ordering\Order\OrderStateEnum::DISPATCHED,
+        'status'          => \App\Enums\Ordering\Order\OrderStatusEnum::SETTLED,
+        'payment_data'    => '{}',
+        'data'            => '{}',
+        'date'            => $date,
+        'created_at'      => $date,
+        'updated_at'      => $date,
+    ]);
+}
+
 function createTrafficSource(Shop $shop, string $type, string $name): TrafficSource
 {
     return TrafficSource::firstOrCreate(


### PR DESCRIPTION
Follows the newsletter figure spotted on `aw/uk`: **102.50 registrations** for a channel that only ever mails people who are already customers.

## The gap

Revenue obeys causality and the attribution window — it counts only invoices raised *after* the touch, and within the window (`WithAttributionWindow`, mirrored by `marketing_attributable_invoices`). The registration and order counts never got the same rule:

- `number_customers` / `registrationsBySource` — plain `SUM(share)` over attributed customers, with no comparison between the touch date and `customers.created_at`. A touch acquires a customer retroactively.
- `number_customer_purchases` — `customer_stats.number_orders_state_dispatched × share`. That rollup carries **no dates at all**, so there was never any way to tell an order the channel earned from one placed years before the touch existed.

On `uk`, 120 of 120 touches happened after the registration they were being credited with.

## Change

- New trait `WithTouchCausality` holds the rule once, parameterised by date column. `WithAttributionWindow` now delegates to it with `invoices.date` — **behaviour and signature unchanged, so the SQL view stays in step**. Doing it the other way (a second copy of the rule) is what previously let a channel's campaigns out-earn the channel.
- Registrations: constrained on `customers.created_at`, in both hydrators and the dashboard.
- Orders: counted from `orders` (`state = dispatched`, not soft-deleted) constrained on `orders.date`, in both hydrators. Verified the new source reproduces the old one exactly before adding the date rule — 71,532 uk customers compared, 71,532 matching, 464,014 orders both ways.
- `TrafficSourceHydrateCustomers` had its own inlined copy of the window rule for revenue; it now uses the trait like the campaign hydrator does.
- New `traffic-source:hydrate-stats` command — stored source rollups otherwise only refresh when a touch fires for that source.

Legacy pivot rows with no `first_touch_at` still count, exactly as they do for revenue, so historic attribution does not vanish on deploy.

## What the numbers do

Almost everything goes to zero, across all 43 non-empty channel rows in prod:

| shop | channel | registrations | orders |
|---|---|---|---|
| uk | newsletter | 111.50 → 0 | 1331 → 0 |
| uk | organic-google | 18.50 → 0 | 460 → 0 |
| uk | organic-bing | 6.00 → 0 | 411 → 0 |
| es | newsletter | 40.00 → 0 | 229 → 0 |
| iteu | organic-bing | 2.00 → 0 | 7 → **1** |

That one surviving order is the only one in the estate placed after the touch claiming it. This is the same correction as revenue's €652,672 → €1,439: capture started on 7 Aug, so every customer carrying touches today registered before those touches existed. The figures will build from real post-capture acquisition.

CAC goes blank wherever registrations are zero, which is correct — spend divided by customers nobody acquired was the misleading part.

## Tests

Two new cases in `TrafficSourceAttributionTest` (touch before vs after registration). New `createDispatchedOrderFor` Pest helper; three existing tests faked orders by writing `customer_stats.number_orders_state_dispatched`, which is no longer the source of truth, and now create real dispatched orders. One fixture in `TrafficSourceCostTest` used a 2023 touch timestamp with a customer registered today — outside the 90-day window, so it now correctly scores zero; moved to a recent touch.

All green, run individually: TrafficSourceAttribution 10, TrafficSourceCost 10, TrafficSourceCampaignStats 6, EmailMarketingPerformance 10, AttributionWindow 6, CustomerJourney 4, MailshotClickAttribution 3, RecalculateTrafficSourceAttribution 6, ShowTrafficSource 3, MarketingPeriod 6, OrderTrafficSourceAttribution 7.

## After deploy

`php artisan traffic-source:hydrate-stats` then `php artisan traffic-source:hydrate-campaign-stats`, otherwise the listing keeps showing the old figures.

---

Still open, deliberately not in here: the campaign block of the dashboard labels a share-weighted **invoice** count as "registrations". Wrong quantity rather than wrong causality, so it needs its own decision.