### PR TITLE
🔬 Instrument traffic source capture: count direct vs unrecognised hits

### DIFF
--- a/app/Actions/Iris/CaptureTrafficSource.php
+++ b/app/Actions/Iris/CaptureTrafficSource.php
@@ -11,6 +11,7 @@ namespace App\Actions\Iris;
 use App\Actions\CRM\TrafficSource\GetTrafficSourceFromRefererHeader;
 use App\Actions\CRM\TrafficSource\GetTrafficSourceFromUrl;
 use App\Enums\Web\Website\WebsiteTypeEnum;
+use Illuminate\Support\Facades\Cache;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class CaptureTrafficSource
@@ -60,41 +61,113 @@ class CaptureTrafficSource
             $trafficSourceData = GetTrafficSourceFromRefererHeader::run($referer);
         }
 
-        if ($trafficSourceData) {
-            $lastTrafficSource = request()->cookie('aiku_lts');
+        if (!$trafficSourceData) {
+            $candidates = $this->refererCandidates($referer);
 
-            if ($lastTrafficSource == $trafficSourceData) {
-                return $cookies;
+            $this->recordCaptureOutcome($candidates === [] ? 'direct' : 'unmatched', $candidates);
+
+            return $cookies;
+        }
+
+        $lastTrafficSource = request()->cookie('aiku_lts');
+
+        if ($lastTrafficSource == $trafficSourceData) {
+            $this->recordCaptureOutcome('repeat');
+
+            return $cookies;
+        }
+
+
+        // Check if the cookie already exists
+        $existingCookieData = request()->cookie('aiku_tsd');
+        if ($existingCookieData) {
+            $appendedTrafficSourceData = $existingCookieData.'|'.now()->utc()->timestamp.$trafficSourceData;
+            $cookieSize                = (4 + strlen('aiku_tsd'.$appendedTrafficSourceData)) / 1024;
+
+            if ($cookieSize > 3.9) {
+                $appendedTrafficSourceData = $this->trimOldestTrafficSource($appendedTrafficSourceData);
             }
 
-
-            // Check if the cookie already exists
-            $existingCookieData = request()->cookie('aiku_tsd');
-            if ($existingCookieData) {
-                $appendedTrafficSourceData = $existingCookieData.'|'.now()->utc()->timestamp.$trafficSourceData;
-                $cookieSize                = (4 + strlen('aiku_tsd'.$appendedTrafficSourceData)) / 1024;
-
-                if ($cookieSize > 3.9) {
-                    $appendedTrafficSourceData = $this->trimOldestTrafficSource($appendedTrafficSourceData);
-                }
-
-                $cookies['aiku_tsd'] = [
-                    'value'    => $appendedTrafficSourceData,
-                    'duration' => 60 * 24 * 120,
-                ];
-            } else {
-                $cookies['aiku_tsd'] = [
-                    'value'    => now()->utc()->timestamp.$trafficSourceData,
-                    'duration' => 60 * 24 * 120,
-                ];
-            }
-            $cookies['aiku_lts'] = [
-                'value'    => $trafficSourceData,
+            $cookies['aiku_tsd'] = [
+                'value'    => $appendedTrafficSourceData,
+                'duration' => 60 * 24 * 120,
+            ];
+        } else {
+            $cookies['aiku_tsd'] = [
+                'value'    => now()->utc()->timestamp.$trafficSourceData,
                 'duration' => 60 * 24 * 120,
             ];
         }
+        $cookies['aiku_lts'] = [
+            'value'    => $trafficSourceData,
+            'duration' => 60 * 24 * 120,
+        ];
+
+        $this->recordCaptureOutcome('matched');
 
         return $cookies;
+    }
+
+    /**
+     * Whether this hit arrived with anything at all that could name a source. A visitor who typed the
+     * address or used a bookmark leaves nothing here, and produces no touch entirely legitimately;
+     * one who arrived from somewhere we failed to recognise leaves a referrer we could not classify.
+     * Counting those two apart is the only way to tell "our traffic is direct" from "capture is
+     * missing sources it should be finding".
+     *
+     * @return array<int, string>
+     */
+    private function refererCandidates(string $referer): array
+    {
+        return array_values(array_filter([
+            request()->headers->get('X-Original-Referer', ''),
+            $referer,
+        ], fn (string $candidate) => filled($candidate) && !str_contains($candidate, (string) request()->getHost())));
+    }
+
+    /**
+     * Per-day counters rather than log lines: this runs on every storefront first hit, so one line per
+     * miss would bury the log and still need counting afterwards. Read them with
+     * `traffic-source:capture-stats`.
+     *
+     * Nothing here may break a page view, hence the catch: a lost counter is a lost counter.
+     *
+     * @param array<int, string> $referers
+     */
+    private function recordCaptureOutcome(string $outcome, array $referers = []): void
+    {
+        try {
+            $day = now()->toDateString();
+            $key = 'traffic_capture:'.$day.':'.$outcome;
+
+            /* add() first so the counter carries an expiry; a bare increment on a missing key leaves
+               it in the store forever. */
+            Cache::add($key, 0, now()->addDays(8));
+            Cache::increment($key);
+
+            if ($outcome !== 'unmatched' || $referers === []) {
+                return;
+            }
+
+            $host = parse_url($referers[0], PHP_URL_HOST);
+
+            if (!$host) {
+                return;
+            }
+
+            /* ponytail: capped so a referrer-spamming crawler cannot grow this without bound; the
+               point is to spot the handful of real sources we are missing, not to log every host. */
+            $hosts = Cache::get('traffic_capture:'.$day.':hosts', []);
+
+            if (count($hosts) >= 100 && !isset($hosts[$host])) {
+                return;
+            }
+
+            $hosts[$host] = ($hosts[$host] ?? 0) + 1;
+            Cache::put('traffic_capture:'.$day.':hosts', $hosts, now()->addDays(8));
+        } catch (\Throwable $e) {
+            report($e);
+        }
     }
 
 

--- a/app/Console/Commands/TrafficSourceCaptureStats.php
+++ b/app/Console/Commands/TrafficSourceCaptureStats.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class TrafficSourceCaptureStats extends Command
+{
+    protected $signature = 'traffic-source:capture-stats {--days=3 : How many days back to report}';
+
+    protected $description = 'Report how often storefront first hits identified a traffic source, and how often they could not';
+
+    /**
+     * Answers the question a registration count cannot: when a visitor arrives with no touch, is that
+     * because they came direct, or because capture failed to recognise where they came from. Counters
+     * are written by CaptureTrafficSource and expire after 8 days.
+     */
+    public function handle(): int
+    {
+        $outcomes = ['matched', 'repeat', 'direct', 'unmatched'];
+        $rows     = [];
+
+        foreach (range((int) $this->option('days') - 1, 0) as $daysAgo) {
+            $day    = now()->subDays($daysAgo)->toDateString();
+            $counts = [];
+
+            foreach ($outcomes as $outcome) {
+                $counts[$outcome] = (int) Cache::get('traffic_capture:'.$day.':'.$outcome, 0);
+            }
+
+            $total      = array_sum($counts);
+            $identified = $counts['matched'] + $counts['repeat'];
+
+            $rows[] = [
+                $day,
+                $total,
+                $counts['matched'],
+                $counts['repeat'],
+                $counts['direct'],
+                $counts['unmatched'],
+                $total > 0 ? round($identified / $total * 100, 1).'%' : '-',
+            ];
+        }
+
+        $this->table(['Day', 'Hits', 'Matched', 'Repeat', 'Direct', 'Unmatched', 'Identified'], $rows);
+
+        $hosts = Cache::get('traffic_capture:'.now()->toDateString().':hosts', []);
+
+        if ($hosts === []) {
+            $this->info('No unrecognised referrers recorded today.');
+
+            return Command::SUCCESS;
+        }
+
+        arsort($hosts);
+
+        $this->newLine();
+        $this->info('Unrecognised referrers today (a source worth mapping would show up here):');
+        $this->table(
+            ['Host', 'Hits'],
+            collect($hosts)->take(20)->map(fn (int $count, string $host) => [$host, $count])->values()->all()
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Unit/Actions/Iris/CaptureTrafficSourceInstrumentationTest.php
+++ b/tests/Unit/Actions/Iris/CaptureTrafficSourceInstrumentationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use App\Actions\Iris\CaptureTrafficSource;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+function captureWith(array $headers = [], string $url = 'https://ancientwisdom.biz/'): void
+{
+    $server = [];
+
+    foreach ($headers as $key => $value) {
+        $server['HTTP_'.str_replace('-', '_', strtoupper($key))] = $value;
+    }
+
+    app()->instance('request', Request::create($url, 'GET', [], [], [], $server));
+
+    CaptureTrafficSource::make()->getCookies();
+}
+
+function captureCount(string $outcome): int
+{
+    return (int) Cache::get('traffic_capture:'.now()->toDateString().':'.$outcome, 0);
+}
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+it('counts a hit with no referrer at all as direct', function () {
+    captureWith();
+
+    expect(captureCount('direct'))->toBe(1)
+        ->and(captureCount('unmatched'))->toBe(0);
+});
+
+it('counts a hit from an unrecognised referrer as unmatched and records the host', function () {
+    captureWith(['X-Original-Referer' => 'https://someforum.example/thread/12']);
+
+    expect(captureCount('unmatched'))->toBe(1)
+        ->and(captureCount('direct'))->toBe(0)
+        ->and(Cache::get('traffic_capture:'.now()->toDateString().':hosts'))
+        ->toBe(['someforum.example' => 1]);
+});
+
+it('does not count the storefront referring itself as an unrecognised source', function () {
+    captureWith(['X-Original-Referer' => 'https://ancientwisdom.biz/products']);
+
+    expect(captureCount('direct'))->toBe(1)
+        ->and(captureCount('unmatched'))->toBe(0);
+});
+
+it('counts an identified source as matched', function () {
+    captureWith(['X-Original-Referer' => 'https://www.google.com/search?q=incense']);
+
+    expect(captureCount('matched'))->toBe(1)
+        ->and(captureCount('direct'))->toBe(0);
+});


### PR DESCRIPTION
Follows the post-deploy check: 51 customers registered this morning while capture was live, and 50 arrived with no touch. That number alone cannot distinguish **"our traffic is genuinely direct"** — normal for B2B wholesale, and correctly producing no touch — from **"capture is failing to recognise sources it should be finding"**. Both look identical from the customer table.

## What it counts

`CaptureTrafficSource::getCookies()` now records an outcome for every storefront first hit:

| outcome | meaning |
|---|---|
| `matched` | a source was identified and a touch cookie written |
| `repeat` | same source as the visitor's last touch, deduped by `aiku_lts` |
| `direct` | no referrer at all, or only the storefront referring itself — a legitimate no-touch |
| `unmatched` | a referrer we could not classify — **the interesting bucket** |

For `unmatched` it also keeps the referring host, so a source worth mapping shows up by name rather than as a number.

## Why counters, not log lines

This runs on every storefront first hit. One line per miss would bury the log and still leave you counting afterwards. These are per-day cache counters with an 8-day expiry, read with:

```
php artisan traffic-source:capture-stats --days=3
```

```
+------------+-------+---------+--------+--------+-----------+------------+
| Day        | Hits  | Matched | Repeat | Direct | Unmatched | Identified |
+------------+-------+---------+--------+--------+-----------+------------+
| 2026-08-07 | 0     | 0       | 0      | 0      | 0         | -          |
+------------+-------+---------+--------+--------+-----------+------------+
```

Two details worth noting in review: `Cache::add()` runs before each `increment()`, because a bare increment on a missing key leaves it in the store with no expiry; and the unmatched-host map is capped at 100 distinct hosts so a referrer-spamming crawler cannot grow it without bound.

## Safety

Wrapped in try/catch and `report()`ed, in the same spirit as `syncDeviceTrafficSources`: this is attribution bookkeeping on the storefront hot path, and a lost counter must never cost a page view. No schema change, no new dependency.

## Tests

4 unit tests in `CaptureTrafficSourceInstrumentationTest`: no referrer → `direct`; unrecognised referrer → `unmatched` plus the host recorded; the storefront referring itself → `direct`, not a false unmatched; a Google referrer → `matched`. Existing `CaptureTrafficSourceTest` still passes (11).

## How to read the result

After a full day: if `identified` is a healthy share and `direct` dominates the rest, capture is working and the traffic really is direct — the zero registrations are honest. If `unmatched` is large, the host list names what we are missing. If `Hits` itself is near zero, the first-hit endpoint is not firing and that is the actual bug.