### PR TITLE
🔗 Referral traffic as its own channel, plus top referrers on the dashboard

### DIFF
--- a/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
+++ b/app/Actions/CRM/TrafficSource/AttachTrafficSourcesToModel.php
@@ -10,6 +10,7 @@ namespace App\Actions\CRM\TrafficSource;
 
 use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceCampaignHydrateStats;
 use App\Actions\CRM\TrafficSource\Hydrator\TrafficSourceHydrateCustomers;
+use App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum;
 use App\Models\CRM\TrafficSource;
 use App\Models\CRM\TrafficSourceCampaign;
 use Illuminate\Support\Carbon;
@@ -20,6 +21,10 @@ use Lorisleiva\Actions\Concerns\AsAction;
 class AttachTrafficSourcesToModel
 {
     use AsAction;
+
+    /* ponytail: a flat cap, enough for every real referrer a shop will ever have. Swap for a
+       rate-limited allow-list only if junk rows actually show up. */
+    private const MAX_REFERRAL_CAMPAIGNS = 200;
 
     /**
      * Resolves the parsed marketing touches into shop traffic sources and campaigns and writes the
@@ -157,7 +162,18 @@ class AttachTrafficSourcesToModel
                else (including the mailshot-N refs, which the click pipeline creates server-side with
                a proper name) must already exist to be credited; otherwise a visitor cycling made-up
                references could mint unlimited campaign rows named whatever they like. */
-            if (!preg_match('/^\d{1,20}$/', $reference)) {
+            /* Referral campaigns are the referring host itself, so they cannot be numeric. They are
+               still client-controlled, hence the hostname shape check and the per-source cap: worst
+               case a spoofed Referer buys a bounded number of junk rows, not unlimited ones. */
+            if ($trafficSource->type === TrafficSourcesTypeEnum::REFERRAL->value) {
+                if (GetTrafficSourceFromRefererHeader::normaliseHost($reference) !== $reference) {
+                    return null;
+                }
+
+                if (TrafficSourceCampaign::where('traffic_source_id', $trafficSource->id)->count() >= self::MAX_REFERRAL_CAMPAIGNS) {
+                    return null;
+                }
+            } elseif (!preg_match('/^\d{1,20}$/', $reference)) {
                 return null;
             }
 

--- a/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
+++ b/app/Actions/CRM/TrafficSource/GetShopMarketingOverview.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\CRM\TrafficSource;
 
+use App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum;
 use App\Enums\UI\Marketing\MarketingPeriodEnum;
 use App\Models\Catalogue\Shop;
 use Illuminate\Support\Carbon;
@@ -31,7 +32,7 @@ class GetShopMarketingOverview
      *
      * All figures are in the shop's currency.
      *
-     * @return array{period: string, period_label: string, from: string|null, currency_code: string, totals: array{spend: float, revenue: float, registrations: float, invoices: float, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: float, roas: float|null}>, campaigns: array<int, array{name: string, channel: string, spend: float, revenue: float, registrations: float, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
+     * @return array{period: string, period_label: string, from: string|null, currency_code: string, referrers: array<int, array{host: string, registrations: float, revenue: float}>, totals: array{spend: float, revenue: float, registrations: float, invoices: float, roas: float|null, cac: float|null}, channels: array<int, array{name: string, type: string, spend: float, revenue: float, registrations: float, roas: float|null}>, campaigns: array<int, array{name: string, channel: string, spend: float, revenue: float, registrations: float, roas: float|null}>, spend_by_day: array<int, array{date: string, amount: float}>}
      */
     public function handle(Shop $shop, MarketingPeriodEnum $period = MarketingPeriodEnum::LAST_30): array
     {
@@ -85,6 +86,7 @@ class GetShopMarketingOverview
             ],
             'channels'      => $channels,
             'campaigns'     => $this->campaigns($shop, $from),
+            'referrers'     => $this->referrers($shop, $from, $window),
             'spend_by_day'  => $this->spendByDay($shop, $from),
         ];
     }
@@ -213,6 +215,58 @@ class GetShopMarketingOverview
                 'roas' => $campaign['spend'] > 0 ? round($campaign['revenue'] / $campaign['spend'], 2) : null,
             ])
             ->sortByDesc(fn (array $campaign) => max($campaign['spend'], $campaign['revenue']))
+            ->take($limit)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * The sites actually sending people here, richest first. Each referring host is a campaign of the
+     * referral channel, so this is the campaign breakdown narrowed to that one channel: trade
+     * directories, blogs, AI assistants. Before referral existed they were all indistinguishable from
+     * someone typing the address in.
+     *
+     * @return array<int, array{host: string, registrations: float, revenue: float}>
+     */
+    private function referrers(Shop $shop, ?Carbon $from, int $window, int $limit = 10): array
+    {
+        $referral = DB::table('traffic_sources')
+            ->where('shop_id', $shop->id)
+            ->where('type', TrafficSourcesTypeEnum::REFERRAL->value)
+            ->value('id');
+
+        if (!$referral) {
+            return [];
+        }
+
+        $registrations = $this->registrationsBy('traffic_source_campaign_id', $shop, $from, $window);
+
+        $revenue = DB::table('invoices')
+            ->join('model_has_traffic_sources as p', function ($join) use ($window) {
+                $join->on('p.model_id', '=', 'invoices.customer_id')
+                    ->where('p.model_type', '=', 'Customer');
+
+                $this->constrainToAttributionWindow($join, $window);
+            })
+            ->where('p.traffic_source_id', $referral)
+            ->where('invoices.shop_id', $shop->id)
+            ->where('invoices.in_process', false)
+            ->when($from, fn ($query) => $query->where('invoices.date', '>=', $from))
+            ->groupBy('p.traffic_source_campaign_id')
+            ->select('p.traffic_source_campaign_id as campaign_id', DB::raw('SUM(invoices.net_amount * p.share) as revenue'))
+            ->pluck('revenue', 'campaign_id');
+
+        return DB::table('traffic_source_campaigns')
+            ->where('traffic_source_id', $referral)
+            ->select('id', 'name')
+            ->get()
+            ->map(fn ($campaign) => [
+                'host'          => $campaign->name,
+                'registrations' => round((float) ($registrations[$campaign->id] ?? 0), 2),
+                'revenue'       => round((float) ($revenue[$campaign->id] ?? 0), 2),
+            ])
+            ->filter(fn (array $referrer) => $referrer['registrations'] > 0 || $referrer['revenue'] > 0)
+            ->sortByDesc(fn (array $referrer) => [$referrer['revenue'], $referrer['registrations']])
             ->take($limit)
             ->values()
             ->all();

--- a/app/Actions/CRM/TrafficSource/GetTrafficSourceFromRefererHeader.php
+++ b/app/Actions/CRM/TrafficSource/GetTrafficSourceFromRefererHeader.php
@@ -73,6 +73,44 @@ class GetTrafficSourceFromRefererHeader
             return TrafficSourcesTypeEnum::abbr()[TrafficSourcesTypeEnum::ORGANIC_TWITTER->value];
         }
 
-        return null;
+        /* Anything else external is a referral rather than nothing: a trade directory, a blog, an AI
+           assistant. Before this they were indistinguishable from someone typing the address in, and
+           whole acquisition channels were invisible. The host travels as the campaign reference so
+           each referrer is reportable on its own. */
+        $host = self::normaliseHost($domain);
+
+        if ($host === null) {
+            return null;
+        }
+
+        return TrafficSourcesTypeEnum::abbr()[TrafficSourcesTypeEnum::REFERRAL->value].$host;
+    }
+
+    /**
+     * A referrer host is only usable as a campaign reference if it is shaped like a hostname: it comes
+     * from a client-controlled header, and it ends up in the customer's stored touch history.
+     *
+     * Returns null for our own systems, which are not marketing sources.
+     */
+    public static function normaliseHost(?string $domain): ?string
+    {
+        $host = strtolower(trim((string) $domain));
+        $host = preg_replace('/^www\./', '', $host) ?? '';
+
+        if (!preg_match('/^(?=.{4,60}$)[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/', $host)) {
+            return null;
+        }
+
+        if ($host === strtolower((string) request()->getHost())) {
+            return null;
+        }
+
+        foreach ((array) config('marketing.internal_referrer_hosts', []) as $internal) {
+            if ($host === $internal || str_ends_with($host, '.'.$internal)) {
+                return null;
+            }
+        }
+
+        return $host;
     }
 }

--- a/app/Actions/CRM/TrafficSource/SyncCustomerTrafficSourcesFromDevice.php
+++ b/app/Actions/CRM/TrafficSource/SyncCustomerTrafficSourcesFromDevice.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\CRM\TrafficSource;
 
+use App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum;
 use App\Models\CRM\Customer;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\DB;
@@ -82,6 +83,10 @@ class SyncCustomerTrafficSourcesFromDevice implements ShouldBeUnique
             ->filter(fn (array $touch) => $touch['timestamp'] !== null
                 && $touch['timestamp'] >= $floor
                 && $touch['timestamp'] <= $ceiling)
+            /* A referral's campaign reference is a hostname taken from a client-controlled header,
+               so it is re-validated here rather than trusted into the customer's history. */
+            ->filter(fn (array $touch) => $touch['type'] !== TrafficSourcesTypeEnum::REFERRAL
+                || GetTrafficSourceFromRefererHeader::normaliseHost($touch['campaign_ref']) === $touch['campaign_ref'])
             ->map(fn (array $touch) => $touch['timestamp'].$touch['abbr'].($touch['campaign_ref'] ?? ''));
 
         return $segments->isEmpty() ? null : $segments->implode('|');

--- a/app/Actions/Iris/CaptureTrafficSource.php
+++ b/app/Actions/Iris/CaptureTrafficSource.php
@@ -122,7 +122,15 @@ class CaptureTrafficSource
         return array_values(array_filter([
             request()->headers->get('X-Original-Referer', ''),
             $referer,
-        ], fn (string $candidate) => filled($candidate) && !str_contains($candidate, (string) request()->getHost())));
+        ], function (string $candidate) {
+            if (blank($candidate)) {
+                return false;
+            }
+
+            /* Our own systems are not a source: the admin app linking to a storefront, or one shop
+               linking to another, would otherwise read as unrecognised traffic worth chasing. */
+            return GetTrafficSourceFromRefererHeader::normaliseHost(parse_url($candidate, PHP_URL_HOST)) !== null;
+        }));
     }
 
     /**
@@ -138,7 +146,12 @@ class CaptureTrafficSource
     {
         try {
             $day = now()->toDateString();
-            $key = 'traffic_capture:'.$day.':'.$outcome;
+
+            /* Split by whether anyone is logged in: the endpoint fires for regulars browsing as well
+               as for first-time visitors, and lumping them together makes "direct" meaningless -
+               a returning customer arriving direct says nothing about how we acquire people. */
+            $audience = auth()->check() ? 'auth' : 'anon';
+            $key      = 'traffic_capture:'.$day.':'.$audience.':'.$outcome;
 
             /* add() first so the counter carries an expiry; a bare increment on a missing key leaves
                it in the store forever. */

--- a/app/Console/Commands/TrafficSourceCaptureStats.php
+++ b/app/Console/Commands/TrafficSourceCaptureStats.php
@@ -28,33 +28,39 @@ class TrafficSourceCaptureStats extends Command
         $rows     = [];
 
         foreach (range((int) $this->option('days') - 1, 0) as $daysAgo) {
-            $day    = now()->subDays($daysAgo)->toDateString();
-            $counts = [];
+            $day = now()->subDays($daysAgo)->toDateString();
 
-            foreach ($outcomes as $outcome) {
-                $counts[$outcome] = (int) Cache::get('traffic_capture:'.$day.':'.$outcome, 0);
+            /* Anonymous first, since that is the row that answers "do new visitors arrive with a
+               source". The logged-in row is mostly regulars returning direct and says little. */
+            foreach (['anon', 'auth'] as $audience) {
+                $counts = [];
+
+                foreach ($outcomes as $outcome) {
+                    $counts[$outcome] = (int) Cache::get('traffic_capture:'.$day.':'.$audience.':'.$outcome, 0);
+                }
+
+                $total      = array_sum($counts);
+                $identified = $counts['matched'] + $counts['repeat'];
+
+                $rows[] = [
+                    $day,
+                    $audience === 'anon' ? 'anonymous' : 'logged in',
+                    $total,
+                    $counts['matched'],
+                    $counts['repeat'],
+                    $counts['direct'],
+                    $counts['unmatched'],
+                    $total > 0 ? round($identified / $total * 100, 1).'%' : '-',
+                ];
             }
-
-            $total      = array_sum($counts);
-            $identified = $counts['matched'] + $counts['repeat'];
-
-            $rows[] = [
-                $day,
-                $total,
-                $counts['matched'],
-                $counts['repeat'],
-                $counts['direct'],
-                $counts['unmatched'],
-                $total > 0 ? round($identified / $total * 100, 1).'%' : '-',
-            ];
         }
 
-        $this->table(['Day', 'Hits', 'Matched', 'Repeat', 'Direct', 'Unmatched', 'Identified'], $rows);
+        $this->table(['Day', 'Visitor', 'Hits', 'Matched', 'Repeat', 'Direct', 'Unmatched', 'Identified'], $rows);
 
         $hosts = Cache::get('traffic_capture:'.now()->toDateString().':hosts', []);
 
         if ($hosts === []) {
-            $this->info('No unrecognised referrers recorded today.');
+            $this->info('No unrecognised referrers recorded today (external ones now record as referral touches).');
 
             return Command::SUCCESS;
         }
@@ -62,7 +68,7 @@ class TrafficSourceCaptureStats extends Command
         arsort($hosts);
 
         $this->newLine();
-        $this->info('Unrecognised referrers today (a source worth mapping would show up here):');
+        $this->info('Referrers rejected today (malformed hosts and our own systems; real ones are recorded as referral touches):');
         $this->table(
             ['Host', 'Hits'],
             collect($hosts)->take(20)->map(fn (int $count, string $host) => [$host, $count])->values()->all()

--- a/app/Enums/CRM/TrafficSource/TrafficSourcesTypeEnum.php
+++ b/app/Enums/CRM/TrafficSource/TrafficSourcesTypeEnum.php
@@ -33,6 +33,7 @@ enum TrafficSourcesTypeEnum: string
     case TWITTER_ADS = 'twitter-ads';
     case YOUTUBE = 'youtube';
     case NEWSLETTER = 'newsletter';
+    case REFERRAL = 'referral';
 
     public static function labels(): array
     {
@@ -53,6 +54,7 @@ enum TrafficSourcesTypeEnum: string
             self::TWITTER_ADS->value       => 'Twitter Ads',
             self::YOUTUBE->value           => 'Youtube',
             self::NEWSLETTER->value        => 'Newsletter',
+            self::REFERRAL->value          => 'Referral',
         ];
     }
 
@@ -75,6 +77,7 @@ enum TrafficSourcesTypeEnum: string
             self::TWITTER_ADS->value       => false,
             self::YOUTUBE->value           => true,
             self::NEWSLETTER->value        => true,
+            self::REFERRAL->value          => true,
         ];
     }
 
@@ -97,6 +100,7 @@ enum TrafficSourcesTypeEnum: string
             self::TWITTER_ADS->value       => 'n',
             self::YOUTUBE->value           => 'o',
             self::NEWSLETTER->value        => 'p',
+            self::REFERRAL->value          => 'q',
         ];
     }
 

--- a/config/marketing.php
+++ b/config/marketing.php
@@ -24,4 +24,23 @@ return [
 
     'attribution_window_days' => env('MARKETING_ATTRIBUTION_WINDOW_DAYS', 90),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Internal referrer hosts
+    |--------------------------------------------------------------------------
+    |
+    | Traffic arriving from our own systems is not a marketing source. A staff
+    | member opening a storefront from the admin app would otherwise be recorded
+    | as a referral, and one shop linking to another as an acquisition.
+    |
+    | Matched as domain suffixes; a visitor arriving from the same host they are
+    | already on is excluded separately.
+    |
+    */
+
+    'internal_referrer_hosts' => [
+        'aiku.io',
+        'aiku.test',
+    ],
+
 ];

--- a/resources/js/Components/DataDisplay/MarketingOverview.vue
+++ b/resources/js/Components/DataDisplay/MarketingOverview.vue
@@ -36,6 +36,11 @@ const props = defineProps<{
         period_label: string
         from: string | null
         period_options: { value: string, label: string }[]
+        referrers: {
+            host: string
+            registrations: number
+            revenue: number
+        }[]
         campaigns: {
             name: string
             channel: string
@@ -298,6 +303,34 @@ const typeLabel: Record<string, string> = {
                             :class="campaign.roas === null ? 'text-gray-300' : campaign.roas >= 1 ? 'text-[#006300]' : 'text-[#d03b3b]'">
                             {{ campaign.roas !== null ? campaign.roas.toFixed(2) + '×' : '—' }}
                         </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Top referrers: the sites sending people here, invisible before the referral channel existed -->
+        <div v-if="overview.referrers?.length" class="rounded-xl ring-1 ring-gray-200 bg-white p-5">
+            <div class="flex items-center justify-between">
+                <div>
+                    <span class="text-sm font-medium text-gray-800">{{ trans('Top referrers') }}</span>
+                    <span class="ml-2 text-xs text-gray-400">{{ overview.period_label.toLowerCase() }}</span>
+                </div>
+            </div>
+
+            <table class="mt-4 w-full text-xs">
+                <thead>
+                    <tr class="text-gray-400 border-b border-gray-100">
+                        <th class="text-left font-normal py-1.5 pr-2">{{ trans('Site') }}</th>
+                        <th class="text-right font-normal py-1.5 px-2">{{ trans('Registrations') }}</th>
+                        <th class="text-right font-normal py-1.5 pl-2">{{ trans('Revenue') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="referrer in overview.referrers" :key="referrer.host"
+                        class="border-b border-gray-50 text-gray-600">
+                        <td class="py-2 pr-2 text-gray-700 truncate max-w-[18rem]">{{ referrer.host }}</td>
+                        <td class="text-right px-2 tabular-nums">{{ fmtShare(referrer.registrations) }}</td>
+                        <td class="text-right pl-2 tabular-nums">{{ money(referrer.revenue) }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/tests/Feature/CRM/ReferralTrafficSourceTest.php
+++ b/tests/Feature/CRM/ReferralTrafficSourceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Fri, 07 Aug 2026
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+/** @noinspection PhpUnhandledExceptionInspection */
+
+use App\Actions\CRM\Customer\StoreCustomer;
+use App\Actions\CRM\TrafficSource\GetShopMarketingOverview;
+use App\Actions\CRM\TrafficSource\GetTrafficSourceFromRefererHeader;
+use App\Enums\CRM\TrafficSource\TrafficSourcesTypeEnum;
+use App\Enums\UI\Marketing\MarketingPeriodEnum;
+use App\Models\CRM\Customer;
+use App\Models\CRM\TrafficSourceCampaign;
+use Illuminate\Support\Facades\Artisan;
+
+beforeAll(function () {
+    loadDB();
+});
+
+beforeEach(function () {
+    Artisan::call('migrate');
+
+    list(
+        $this->organisation,
+        $this->user,
+        $this->shop
+    ) = createShop();
+
+    $this->referral = createTrafficSource($this->shop, 'referral', 'Referral');
+});
+
+it('records an unrecognised external referrer as a referral touch carrying its host', function () {
+    $touch = GetTrafficSourceFromRefererHeader::run('https://www.esources.co.uk/directory/x');
+
+    expect($touch)->toBe(TrafficSourcesTypeEnum::abbr()[TrafficSourcesTypeEnum::REFERRAL->value].'esources.co.uk');
+});
+
+it('still prefers a known channel over the referral fallback', function () {
+    expect(GetTrafficSourceFromRefererHeader::run('https://www.google.com/search?q=x'))
+        ->toBe(TrafficSourcesTypeEnum::abbr()[TrafficSourcesTypeEnum::ORGANIC_GOOGLE->value]);
+});
+
+it('does not treat our own systems as a referral', function () {
+    expect(GetTrafficSourceFromRefererHeader::run('https://app.aiku.io/org/aw'))->toBeNull()
+        ->and(GetTrafficSourceFromRefererHeader::normaliseHost('not a host'))->toBeNull();
+});
+
+it('creates a campaign per referring host and shows it in the dashboard top referrers', function () {
+    $customer = StoreCustomer::make()->action(
+        $this->shop,
+        array_merge(Customer::factory()->definition(), [
+            'traffic_sources' => now()->subDay()->timestamp.'qesources.co.uk',
+        ])
+    );
+
+    createInvoiceFor($customer, $this->shop, now()->toDateTimeString(), 250);
+
+    $campaign = TrafficSourceCampaign::where('traffic_source_id', $this->referral->id)
+        ->where('reference', 'esources.co.uk')
+        ->first();
+
+    expect($campaign)->not->toBeNull();
+
+    $referrers = collect(GetShopMarketingOverview::run($this->shop, MarketingPeriodEnum::LAST_7)['referrers'])
+        ->keyBy('host');
+
+    expect($referrers['esources.co.uk']['registrations'])->toBe(1.0)
+        ->and($referrers['esources.co.uk']['revenue'])->toBe(250.0);
+});
+
+it('refuses a referral campaign whose reference is not a hostname', function () {
+    StoreCustomer::make()->action(
+        $this->shop,
+        array_merge(Customer::factory()->definition(), [
+            'traffic_sources' => now()->subDay()->timestamp.'qnot-a-host',
+        ])
+    );
+
+    /* Asserted by reference, not by count: createShop() reuses the shop across the file, so the
+       referral source still carries the campaign the earlier test created. */
+    expect(TrafficSourceCampaign::where('traffic_source_id', $this->referral->id)
+        ->where('reference', 'not-a-host')->exists())->toBeFalse();
+});

--- a/tests/Unit/Actions/Iris/CaptureTrafficSourceInstrumentationTest.php
+++ b/tests/Unit/Actions/Iris/CaptureTrafficSourceInstrumentationTest.php
@@ -23,9 +23,9 @@ function captureWith(array $headers = [], string $url = 'https://ancientwisdom.b
     CaptureTrafficSource::make()->getCookies();
 }
 
-function captureCount(string $outcome): int
+function captureCount(string $outcome, string $audience = 'anon'): int
 {
-    return (int) Cache::get('traffic_capture:'.now()->toDateString().':'.$outcome, 0);
+    return (int) Cache::get('traffic_capture:'.now()->toDateString().':'.$audience.':'.$outcome, 0);
 }
 
 beforeEach(function () {
@@ -39,13 +39,26 @@ it('counts a hit with no referrer at all as direct', function () {
         ->and(captureCount('unmatched'))->toBe(0);
 });
 
-it('counts a hit from an unrecognised referrer as unmatched and records the host', function () {
+it('counts a hit from an external site we do not recognise as a matched referral', function () {
     captureWith(['X-Original-Referer' => 'https://someforum.example/thread/12']);
 
-    expect(captureCount('unmatched'))->toBe(1)
+    expect(captureCount('matched'))->toBe(1)
         ->and(captureCount('direct'))->toBe(0)
-        ->and(Cache::get('traffic_capture:'.now()->toDateString().':hosts'))
-        ->toBe(['someforum.example' => 1]);
+        ->and(captureCount('unmatched'))->toBe(0);
+});
+
+it('does not count our own admin app as a referral', function () {
+    captureWith(['X-Original-Referer' => 'https://app.aiku.io/org/aw/shops/uk']);
+
+    expect(captureCount('direct'))->toBe(1)
+        ->and(captureCount('matched'))->toBe(0);
+});
+
+it('counts anonymous and logged in visitors separately', function () {
+    captureWith();
+
+    expect(captureCount('direct', 'anon'))->toBe(1)
+        ->and(captureCount('direct', 'auth'))->toBe(0);
 });
 
 it('does not count the storefront referring itself as an unrecognised source', function () {


### PR DESCRIPTION
The capture counters shipped in #2548 immediately turned up three unrecognised referrers on prod: **www.esources.co.uk** (a B2B trade directory), **chatgpt.com**, and **app.aiku.io** (our own admin). The first two are real acquisition channels we were discarding into "direct"; the third is noise that should never have been counted.

## 1. `referral` channel

New `TrafficSourcesTypeEnum::REFERRAL` (abbr `q`). Any external referrer that matches no known platform now records as a referral touch **carrying the referring host as its campaign reference**, so each referring site is reportable on its own rather than collapsing into one bucket.

Known platforms still win — a Google referrer is still organic-google, not a referral.

**Requires `php artisan traffic-source:seed` after deploy**, or shops have no referral row and every referral touch is silently discarded — the exact failure that lost a day of newsletter clicks.

## 2. Top referrers on the dashboard

`GetShopMarketingOverview` gains a `referrers` block: the top 10 referring hosts by revenue, with registrations and revenue, under the same causality and attribution-window rules as everything else. Rendered as a "Top referrers" table in `MarketingOverview.vue`.

Each host is a campaign of the referral channel, so this is the existing campaign machinery narrowed to one channel — no new stats table.

## 3. Trust boundary

The host arrives in a client-controlled `Referer`, and ends up in the customer's stored touch history, so it is validated three times:

- at capture, `normaliseHost()` lowercases, strips `www.`, and requires a 4–60 char hostname shape;
- again in `SyncCustomerTrafficSourcesFromDevice::sanitize()`, which rebuilds the touch string from client data;
- referral campaign auto-creation is capped at **200 per source**, so a spoofed Referer buys a bounded number of junk rows rather than unlimited ones. The existing numeric-only rule still applies to every other channel.

Our own hosts (`config('marketing.internal_referrer_hosts')`: `aiku.io`, `aiku.test`) are excluded everywhere, plus the visitor's current host.

## 4. Counters split by visitor type

`matched`/`repeat`/`direct`/`unmatched` are now recorded separately for anonymous and logged-in visitors. The endpoint fires for regulars browsing as well as first-time visitors, so yesterday's "87% direct" mixed the two and could not answer whether *new* visitors arrive with a source. `traffic-source:capture-stats` prints a row per visitor type, anonymous first.

The unmatched bucket now means "malformed or internal", since real external hosts become referrals.

## Tests

`ReferralTrafficSourceTest` (5): an unrecognised external referrer produces `q` + host; a known channel still wins; our own admin app is not a referral; a referring host becomes a campaign and appears in the dashboard's top referrers with its registrations and revenue; a non-hostname reference creates no campaign.

`CaptureTrafficSourceInstrumentationTest` updated to the new outcomes (6). Also green: CaptureTrafficSource 11, SanitizeDeviceTouches 5, TrafficSourceAttribution 10, TrafficSourceCampaignStats 8, MarketingPeriod 6, AttributionDataQuality 7.

## After deploy

```
php artisan traffic-source:seed
```